### PR TITLE
Fix grammar in firmware 2.0 microSD requirement

### DIFF
--- a/sidecartridge-multidevice/getting_started_v2.md
+++ b/sidecartridge-multidevice/getting_started_v2.md
@@ -96,7 +96,7 @@ Since revision 3.1 of the board, the Raspberry Pi Pico W can be directly soldere
 {: refdef}
 
 
-- Since the firmware version 2.0, a microSD card [formatted as FAT32 or exFAT](https://docs.sidecartridge.com/sidecartridge-multidevice/how_to_v2/#format-the-microsd-card) is required.
+- Since firmware version 2.0, a microSD card [formatted as FAT32 or exFAT](https://docs.sidecartridge.com/sidecartridge-multidevice/how_to_v2/#format-the-microsd-card) is required.
 
 ## Initial Setup and Configuration
 


### PR DESCRIPTION
## Summary
- remove the stray definite article in the Multidevice getting-started doc ("Since firmware version 2.0")
- documentation-only polish; applies Teemu Hukkanen's email patch
