### PR TITLE
docs: expand Mega ST six-ROM conversion

### DIFF
--- a/sidecartridge-tos/hardware-installation.md
+++ b/sidecartridge-tos/hardware-installation.md
@@ -136,11 +136,9 @@ If your computer already has two ROMs installed, the jumpers should be already s
 
 Not supported as-is. Convert the board to the dual-ROM layout before installing the TOS Emulator:
 
-1. Remove the six 256 Kbit ROMs and fit the standard dual-ROM daughterboard or two 32-pin sockets wired for FC-L / FC-H.
-2. Install a **74LS11** (triple AND gate) in the empty IC footprint located immediately to the right of jumper **W4** and above **W2**. Atari left that socket unpopulated on six-ROM machines; the dual-ROM configuration requires it for address decoding.
-3. Move **W2** and **W3** to the 2-3 position and leave **W4** open.
+1. Remove the six 256 Kbit ROMs.
 
-Once those changes are done the motherboard exposes the same HI/LO sockets as later Mega ST revisions, so the SidecarTridge board drops in normally.
+Once that change is done the motherboard exposes the same HI/LO sockets as later Mega ST revisions, so the SidecarTridge board drops in normally.
 
 ### Atari STE
 

--- a/sidecartridge-tos/hardware-installation.md
+++ b/sidecartridge-tos/hardware-installation.md
@@ -134,7 +134,13 @@ If your computer already has two ROMs installed, the jumpers should be already s
 
 #### Six ROMs
 
-Not supported. Modify the jumpers to support dual ROMs as described above.
+Not supported as-is. Convert the board to the dual-ROM layout before installing the TOS Emulator:
+
+1. Remove the six 256 Kbit ROMs and fit the standard dual-ROM daughterboard or two 32-pin sockets wired for FC-L / FC-H.
+2. Install a **74LS11** (triple AND gate) in the empty IC footprint located immediately to the right of jumper **W4** and above **W2**. Atari left that socket unpopulated on six-ROM machines; the dual-ROM configuration requires it for address decoding.
+3. Move **W2** and **W3** to the 2-3 position and leave **W4** open.
+
+Once those changes are done the motherboard exposes the same HI/LO sockets as later Mega ST revisions, so the SidecarTridge board drops in normally.
 
 ### Atari STE
 

--- a/sidecartridge-tos/hardware-installation.md
+++ b/sidecartridge-tos/hardware-installation.md
@@ -137,8 +137,10 @@ If your computer already has two ROMs installed, the jumpers should be already s
 Not supported as-is. Convert the board to the dual-ROM layout before installing the TOS Emulator:
 
 1. Remove the six 256 Kbit ROMs.
+2. Install a **74LS11** (triple AND gate) in the empty IC footprint located immediately to the right of jumper **W4** and above **W2**. Atari left that socket unpopulated on six-ROM machines; the dual-ROM configuration requires it for address decoding.
+3. Move **W2** and **W3** to the 2-3 position and leave **W4** open.
 
-Once that change is done the motherboard exposes the same HI/LO sockets as later Mega ST revisions, so the SidecarTridge board drops in normally.
+Once those changes are done the motherboard exposes the same HI/LO sockets as later Mega ST revisions, so the SidecarTridge board drops in normally.
 
 ### Atari STE
 


### PR DESCRIPTION
## Summary\n- clarify that Mega ST boards shipping with six ROMs must be converted before using the TOS Emulator\n- add the missing step about installing the 74LS11 gate near W4/W2 during that conversion\n\n## Testing\n- not run (docs only)