### PR TITLE
docs: remove Discord references

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,7 +90,7 @@ nav_external_links:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "<span>© 2024-25 GOODDATA LABS SL | Looking for support? Join our <a href='https://discord.com/invite/u73QP9MEYC'>Discord</a> or <a href='mailto:support@gooddatalabs.com'>email us!</a></span>"
+footer_content: "<span>© 2024-25 GOODDATA LABS SL | Looking for support? <a href='mailto:support@gooddatalabs.com'>Email us</a>.</span>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/index.md
+++ b/index.md
@@ -20,8 +20,6 @@ has_toc: false
 
 # SidecarTridge Documentation Site
 
-![Discord](https://img.shields.io/discord/1160868666162823218?style=flat&label=Discord&link=https%3A%2F%2Fdiscord.com%2Finvite%2Fu73QP9MEYC)
-
 <!-- Project list – single column with left thumbnail -->
 <style>
   .proj-list {
@@ -186,5 +184,5 @@ has_toc: false
 </div>
 
 <div class="support-note">
-  Looking for support? <a href="https://discord.com/invite/u73QP9MEYC">Join our Discord server</a> or <a href="mailto:support@gooddatalabs.com">drop us an email</a>!
+  Looking for support? <a href="mailto:support@gooddatalabs.com">Drop us an email</a> anytime.
 </div>

--- a/sidecartridge-multidevice/issues.md
+++ b/sidecartridge-multidevice/issues.md
@@ -60,7 +60,7 @@ When reporting an issue, please provide as much detail as possible to help us un
 - Computer memory size (if applicable).
 - Any other devices connected to the computer, such as hard drives or floppy drives (if applicable).
 
-If you have any doubts about how to report an issue, please feel free to join the [SidecarTridge Discord Server](https://discord.com/invite/u73QP9MEYC) and ask for help. 
+If you have any doubts about how to report an issue, please reach out via email (support@gooddatalabs.com) and we'll help you shape it.
 
 Also LLMs like ChatGPT, Perplexity or Gemini can help you to draft a good issue report based on your inputs.
 


### PR DESCRIPTION
## Summary\n- Remove all residual Discord references (badges, footer CTA, issue-report hint) so the docs site no longer links to the server.\n\n## Testing\n- not run (docs only)