### PR TITLE
docs: align Multidevice guides with Booster 2.1.0

### DIFF
--- a/sidecartridge-multidevice/getting_started_v2.md
+++ b/sidecartridge-multidevice/getting_started_v2.md
@@ -51,8 +51,14 @@ Firmware v2 introduces a new architecture for the SidecarTridge Multi-device tha
 * **⚙️ Per-app Configurations**
   Each Microfirmware stores its own settings in flash memory, isolated from other apps. This allows you to easily switch between functions without losing or reconfiguring settings.
 
+* **🛰️ Offline-safe Manager + Atari terminal shortcuts**
+  Booster v2.1 keeps the Manager usable even if Wi-Fi never connects: press `ESC` on the Atari ST terminal to list the downloaded apps or hold `SHIFT` to keep booting from GEMDOS, and launch microfirmwares without the web UI.
+
 * **🛠️ Optimized Development Workflow & Architecture**
   The v2 architecture separates the core firmware, global settings, and Microfirmwares — making the platform easier to extend and maintain. For developers, this enables a fast test cycle: build ST software on PC/Mac/Linux, test in an emulator, then copy to the device as a microfirmware. Expect faster innovation and more community-contributed Microfirmwares.
+
+* **📶 Live signal + MAC telemetry**
+  The Manager screen and the shared web status banner show Wi-Fi signal strength (RSSI) and the Pico W MAC address, making it easier to debug weak networks or add the device to router allow-lists.
 
 * **⬆️ Adaptive bus speed for Atari Falcon, TT and accelerated computers**
   The new firmware can automatically adjust the bus speed to ensure compatibility with a wider range of Atari computers, including Falcon and TT models, as well as accelerated systems. This means improved performance and stability across different hardware configurations.
@@ -177,6 +183,8 @@ picotool load -xv dist/rp-booster-$VERSION.uf2
     ![Booster Maneger Mode step 2](/sidecartridge-multidevice/assets/images/BOOSTER-MANAGER-2.png)
 
     Your WiFi setup is now complete. From now on, the Booster app will boot directly into **Manager mode**. 
+
+    Even if Wi-Fi never connects, Booster v2.1.0 no longer leaves you stranded: after the retry cycle it keeps the Atari ST terminal active so you can press `ESC` to open the apps workflow or hold any `SHIFT` key to keep booting from GEMDOS. From there you can launch the microfirmwares you already downloaded, entirely offline.
 
     If you later notice unstable connectivity, newer firmware versions can also show the signal strength directly on the Atari ST screen, without the need to enter **Manager mode** in the Booster app. You can also open the **WiFi view** and enable **Show RSSI** to display the RSSI value in dBm for visible WiFi networks. As a general reference, use the first matching threshold in the table below.
 

--- a/sidecartridge-multidevice/getting_started_v2.md
+++ b/sidecartridge-multidevice/getting_started_v2.md
@@ -184,7 +184,7 @@ picotool load -xv dist/rp-booster-$VERSION.uf2
 
     Your WiFi setup is now complete. From now on, the Booster app will boot directly into **Manager mode**. 
 
-    Even if Wi-Fi never connects, Booster v2.1.0 no longer leaves you stranded: after the retry cycle it keeps the Atari ST terminal active so you can press `ESC` to open the apps workflow or hold any `SHIFT` key to keep booting from GEMDOS. From there you can launch the microfirmwares you already downloaded, entirely offline.
+    Starting with Booster v2.1.0, even if Wi-Fi never connects you are no longer stranded: after the retry cycle the Atari ST terminal stays active so you can press `ESC` to open the apps workflow or hold any `SHIFT` key to keep booting from GEMDOS. From there you can launch the microfirmwares you already downloaded, entirely offline.
 
     If you later notice unstable connectivity, newer firmware versions can also show the signal strength directly on the Atari ST screen, without the need to enter **Manager mode** in the Booster app. You can also open the **WiFi view** and enable **Show RSSI** to display the RSSI value in dBm for visible WiFi networks. As a general reference, use the first matching threshold in the table below.
 

--- a/sidecartridge-multidevice/getting_started_v2.md
+++ b/sidecartridge-multidevice/getting_started_v2.md
@@ -52,7 +52,7 @@ Firmware v2 introduces a new architecture for the SidecarTridge Multi-device tha
   Each Microfirmware stores its own settings in flash memory, isolated from other apps. This allows you to easily switch between functions without losing or reconfiguring settings.
 
 * **🛰️ Offline-safe Manager + Atari terminal shortcuts**
-  Booster v2.1 keeps the Manager usable even if Wi-Fi never connects: press `ESC` on the Atari ST terminal to list the downloaded apps or hold `SHIFT` to keep booting from GEMDOS, and launch microfirmwares without the web UI.
+  Starting with Booster v2.1.0, the Manager stays usable even if Wi-Fi never connects: press `ESC` on the Atari ST terminal to list the downloaded apps or hold `SHIFT` to keep booting from GEMDOS, and launch microfirmwares without the web UI.
 
 * **🛠️ Optimized Development Workflow & Architecture**
   The v2 architecture separates the core firmware, global settings, and Microfirmwares — making the platform easier to extend and maintain. For developers, this enables a fast test cycle: build ST software on PC/Mac/Linux, test in an emulator, then copy to the device as a microfirmware. Expect faster innovation and more community-contributed Microfirmwares.

--- a/sidecartridge-multidevice/microfirmwares/index.md
+++ b/sidecartridge-multidevice/microfirmwares/index.md
@@ -34,7 +34,7 @@ has_toc: false
 A Microfirmware app is a small, self-contained program that runs on a standalone RP2040 or RP235x chip, along with a companion firmware on your computer that talks to it. Together, they provide the features of the device.
 
 ### Launching microfirmwares from the Atari ST terminal
-Booster v2.1.0 lets you launch any microfirmware that is already downloaded even when Wi-Fi is unavailable. When the Manager screen appears on the Atari ST:
+Starting with Booster v2.1.0 you can launch any microfirmware that is already downloaded even when Wi-Fi is unavailable. When the Manager screen appears on the Atari ST:
 
 - Press `ESC` to enter the terminal-driven apps workflow. Use the keyboard to pick the microfirmware you want to boot.
 - Hold any `SHIFT` key if you simply want to keep booting from GEMDOS without touching the web UI.

--- a/sidecartridge-multidevice/microfirmwares/index.md
+++ b/sidecartridge-multidevice/microfirmwares/index.md
@@ -33,6 +33,14 @@ has_toc: false
 
 A Microfirmware app is a small, self-contained program that runs on a standalone RP2040 or RP235x chip, along with a companion firmware on your computer that talks to it. Together, they provide the features of the device.
 
+### Launching microfirmwares from the Atari ST terminal
+Booster v2.1.0 lets you launch any microfirmware that is already downloaded even when Wi-Fi is unavailable. When the Manager screen appears on the Atari ST:
+
+- Press `ESC` to enter the terminal-driven apps workflow. Use the keyboard to pick the microfirmware you want to boot.
+- Hold any `SHIFT` key if you simply want to keep booting from GEMDOS without touching the web UI.
+
+This offline-safe launcher is useful when the access point is down, the router blocks the device, or you just prefer not to open the web interface.
+
 ### Available Microfirmware Apps
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.2rem; margin-top: 1rem;">

--- a/sidecartridge-multidevice/userguide_v2.md
+++ b/sidecartridge-multidevice/userguide_v2.md
@@ -35,7 +35,11 @@ Thanks to the  Booster Manager Mode, users can now easily manage microfirmware a
 
 In **Manager mode**, the Booster app will automatically connect to your configured WiFi network and will automatically connect to the public repository of microfirmware apps, displaying them in the web interface. The web interface is accessible from any computer or mobile device connected to the same WiFi network as the Booster app.
 
+If Wi-Fi negotiations fail, Booster v2.1.0 falls back to an offline-safe Manager: the Atari ST terminal remains active so you can still boot the microfirmwares that are already downloaded. Press `ESC` on the terminal to enter the apps workflow, or hold any `SHIFT` key to keep booting from GEMDOS without touching the web UI.
+
 If your DHCP network supports a DNS with `.local` domains, you can access the web interface using `http://sidecart.local`. Otherwise, use the IP address assigned by your DHCP server and visible on your computer screen.
+
+The Atari ST Manager screen and the shared web status banner also show live Wi-Fi signal strength and the Pico W MAC address, and Booster replies to ICMP ping requests while connected so network troubleshooting is easier.
 
 > **Note**: The device needs a SDHC or SDXC microSD card formatted with **exFAT** or **FAT32** file system to work properly. The app will warn the user if the microSD card is not present or not formatted correctly.
 
@@ -47,7 +51,7 @@ The **Apps view** shows:
 - The list of installed apps on the device.
 - The list of apps that are not installed but are available on the microSD card.
 
-This view is the default view when you access the web interface.
+This view is the default view when you access the web interface. At the top of the Apps page you can use the **Platform** and **Features** filters to narrow the catalog dynamically without scrolling through every entry.
 
 ![Booster Manager Apps View 1](/sidecartridge-multidevice/assets/images/BOOSTER-MANAGER-APPS-1.png)
 
@@ -69,6 +73,8 @@ At the right hand side of each app, you can see the following buttons:
 ![Booster Manager Apps View 3](/sidecartridge-multidevice/assets/images/BOOSTER-MANAGER-APPS-3.png)
 
 When launching an app, the computer screen will show a message indicating that the app is being launched. The Booster app will make its best effort to also reboot the computer, but this may not always be possible. So assume that the computer is not rebooted and you need to do it manually.
+
+When the ST keyboard is handy you can also press `ESC` to open the terminal-driven apps workflow or hold `SHIFT` to continue booting from GEMDOS. That manual launcher works even if Wi-Fi is unavailable, so any microfirmware already downloaded remains usable in offline scenarios.
 
 The Booster microfirmware app is now installed in the flash memory of the device, and every time you power on the device, it will automatically launch the app. 
 
@@ -109,7 +115,7 @@ It's also possible to change the WiFi network. To do this, click on the new WiFi
 
 The Booster app will save the WiFi credentials to flash memory and reboot. It will then connect to your WiFi network and show a message on the computer screen.
 
-> **Note**: If the Booster app is not able to connect to the WiFi network, press SELECT button for ten seconds and power off and power on the device and the computer to start the Factory mode again.
+> **Note**: If the Booster app is not able to connect to the WiFi network, Booster v2.1.0 will stay in offline Manager mode so you can still launch already-downloaded apps from the keyboard. Only press the SELECT button for ten seconds (to return to Factory mode) if you actually need to reconfigure Wi-Fi from scratch.
 
 ### Device view
 

--- a/sidecartridge-multidevice/userguide_v2.md
+++ b/sidecartridge-multidevice/userguide_v2.md
@@ -35,7 +35,7 @@ Thanks to the  Booster Manager Mode, users can now easily manage microfirmware a
 
 In **Manager mode**, the Booster app will automatically connect to your configured WiFi network and will automatically connect to the public repository of microfirmware apps, displaying them in the web interface. The web interface is accessible from any computer or mobile device connected to the same WiFi network as the Booster app.
 
-If Wi-Fi negotiations fail, Booster v2.1.0 falls back to an offline-safe Manager: the Atari ST terminal remains active so you can still boot the microfirmwares that are already downloaded. Press `ESC` on the terminal to enter the apps workflow, or hold any `SHIFT` key to keep booting from GEMDOS without touching the web UI.
+Starting with Booster v2.1.0, if Wi-Fi negotiations fail the Manager falls back to an offline-safe mode: the Atari ST terminal remains active so you can still boot the microfirmwares that are already downloaded. Press `ESC` on the terminal to enter the apps workflow, or hold any `SHIFT` key to keep booting from GEMDOS without touching the web UI.
 
 If your DHCP network supports a DNS with `.local` domains, you can access the web interface using `http://sidecart.local`. Otherwise, use the IP address assigned by your DHCP server and visible on your computer screen.
 
@@ -115,7 +115,7 @@ It's also possible to change the WiFi network. To do this, click on the new WiFi
 
 The Booster app will save the WiFi credentials to flash memory and reboot. It will then connect to your WiFi network and show a message on the computer screen.
 
-> **Note**: If the Booster app is not able to connect to the WiFi network, Booster v2.1.0 will stay in offline Manager mode so you can still launch already-downloaded apps from the keyboard. Only press the SELECT button for ten seconds (to return to Factory mode) if you actually need to reconfigure Wi-Fi from scratch.
+> **Note**: If the Booster app is not able to connect to the WiFi network, Starting with Booster v2.1.0 the Manager will stay in offline mode so you can still launch already-downloaded apps from the keyboard. Only press the SELECT button for ten seconds (to return to Factory mode) if you actually need to reconfigure Wi-Fi from scratch.
 
 ### Device view
 


### PR DESCRIPTION
## Summary
- highlight the new offline-safe Manager behavior and Atari-terminal launcher shortcuts in getting_started_v2 and userguide_v2
- document the Platform/Features filters plus the live signal/MAC telemetry that shipped with Booster 2.1.0
- add a microfirmwares/index section that explains how to launch downloaded apps directly from the Atari ST keyboard when Wi-Fi is unavailable

## Testing
- viewed the modified markdown locally