### PR TITLE
docs: add TOS history part II link to compatibility page

### DIFF
--- a/sidecartridge-tos/compatibility.md
+++ b/sidecartridge-tos/compatibility.md
@@ -168,6 +168,10 @@ You can learn about the different TOS versions in these videos:
         allowfullscreen allowtransparency></iframe>
 </figure>
 
+And the follow-up video covering the 256 KB ROM family is here:
+
+- [Atari ST TOS History with SidecarTridge TOS Emulator (Part II)](https://www.youtube.com/watch?v=76bVhYGFCXU)
+
 [Previous: User Guide](/sidecartridge-tos/user-guide/){: .btn .mr-4 }
 [Main](/sidecartridge-tos/){: .btn .mr-4 }
 [Next: Troubleshooting](/sidecartridge-tos/troubleshooting/){: .btn }


### PR DESCRIPTION
## Summary
- add the Part II TOS history video link at the end of the compatibility page
- keep the existing embedded Part I video in place

## Why
This gives users a direct link to the follow-up video covering the 256 KB ROM family and STE/Mega STE context.