### PR TITLE
docs: add ACSI2STM Compact enclosure listing

### DIFF
--- a/acsi2stm-atari-st/cases.md
+++ b/acsi2stm-atari-st/cases.md
@@ -22,7 +22,9 @@ parent: ACSI2STM Hard Disk for Atari ST
 
 ### Compact Revision 2.x 
 
-| ![SidecarTridge ACSI2STM Enclosure by Alan_UK](https://cdn.thingiverse.com/assets/09/fa/9b/90/72/large_display_ACSI2STM_SidecarTridge_Enclosure_V1.1_Mounted_on_AtariST-_annotated.jpg) | **SidecarTridge ACSI2STM Enclosure by Alan_UK**: This enclosure is designed for the ACSI2STM SidecarTridge released in early 2025, commonly referred to as the "Castillian" version, named after its distinctive castellated shape. This revision features spring-loaded SD slots and enhanced circuitry.[View on Thingiverse](https://www.thingiverse.com/thing:7011991) |
+| ![SidecarTridge ACSI2STM Enclosure by Alan_UK](https://cdn.thingiverse.com/assets/09/fa/9b/90/72/large_display_ACSI2STM_SidecarTridge_Enclosure_V1.1_Mounted_on_AtariST-_annotated.jpg) | **SidecarTridge ACSI2STM Enclosure by Alan_UK**: This enclosure is designed for the ACSI2STM SidecarTridge released in early 2025, commonly referred to as the "Castillian" version, named after its distinctive castellated shape. This revision features spring-loaded SD slots and enhanced circuitry. [View on Thingiverse](https://www.thingiverse.com/thing:7011991) |
+
+| ![ACSI2STM Compact Enclosure by SidecarTridge](https://media.printables.com/media/prints/1a97425b-37fb-4764-8dc4-9e165a97afb8/images/12608050_dd140479-ebeb-4d53-9f88-dd04e3604963_3a87d596-719c-4063-973f-43097f854a0e/thumbs/cover/1200x630/jpg/img_9731.jpg) | **ACSI2STM Compact Enclosure by SidecarTridge**: This enclosure is designed for the ACSI2STM Compact by SidecarTridge (REV1.0.0). It is offered as a free community-printable enclosure made of a base and a lid, with no screws required. It is available for anyone who wants to print it, but it is **not sold by SidecarTridge**. [View on Printables](https://www.printables.com/model/1679552-acsi2stm-compact-enclosure) |
 
 ### Mini Revision 1.0
 


### PR DESCRIPTION
## Summary
- add the new SidecarTridge ACSI2STM Compact enclosure to the cases page
- use the Printables image as illustration
- clarify that the enclosure is available for community printing but is not sold by SidecarTridge

## Reference
Printables model: https://www.printables.com/model/1679552-acsi2stm-compact-enclosure