### PR TITLE
docs: simplify ACSI2STM driver mentions and link compatibility list

### DIFF
--- a/acsi2stm-atari-st/before-buy.md
+++ b/acsi2stm-atari-st/before-buy.md
@@ -25,21 +25,11 @@ If you don't want to take the risk of the Bad-DMA issue, the [SidecarTridge Mult
 
 The ACSI2STM device has two main modes of operation: the ACSI mode and the GEMDRIVE mode. Not all the TOS versions supports both modes. The ACSI mode is the legacy mode that uses the ACSI protocol to communicate with the Atari ST. The GEMDRIVE mode is the modern mode that traps the GEMDOS calls to access the SD card. 
 
-We have tested the ACSI2STM device with the following TOS versions with the following results:
+We have tested the ACSI2STM device with different TOS versions and modes, but instead of duplicating that matrix here, please refer to the official compatibility list:
 
-Here is the data split into a table with the requested columns:
+- [Official ACSI2STM compatibility list](https://github.com/retro16/acsi2stm/blob/stable/doc/compatibility.md)
 
-| **TOS Version** | **ACSI Supported**                  | **GEMDRIVE Supported**           |
-|------------------|------------------------------------|-----------------------------------|
-| TOS 1.00         | HDDriver                           | No             |
-| TOS 1.02         | HDDriver                           | No             |
-| TOS 1.04         | HDDriver + ICD driver              | Yes            |
-| TOS 1.62         | HDDriver + ICD driver              | Yes            |
-| TOS 1.62         | HDDriver + ICD driver              | Yes            |
-| TOS 2.06         | HDDriver + ICD driver              | Yes            |
-| EmuTOS 1.3.0     | Integrated ACSI driver             | Yes            |
-
-If you need support for large size partitions in TOS 1.00 or 1.02, the [SidecarTridge MultiDevice](https://sidecartridge.com/products/sidecartridge-multidevice-atari-st/) GEMDRIVE is a good alternative.
+If you need support for large size partitions in older TOS versions, the [SidecarTridge MultiDevice](https://sidecartridge.com/products/sidecartridge-multidevice-atari-st/) GEMDRIVE is a good alternative.
 
 ### Creating images for the ACSI mode
 

--- a/acsi2stm-atari-st/faq.md
+++ b/acsi2stm-atari-st/faq.md
@@ -22,7 +22,7 @@ parent: ACSI2STM Hard Disk for Atari ST
 ### What is the difference between GEMDRIVE and ACSI modes?
 
 - **GEMDRIVE Mode**: Allows easy file transfers between Atari and modern PCs using FAT16, FAT32, or ExFAT formatted SD cards. No additional drivers are needed.  
-- **ACSI Mode**: Emulates a traditional ACSI hard drive, supporting legacy Atari software with custom partitions. Requires Atari hard disk drivers like HDDRIVER or ICD Pro.  
+- **ACSI Mode**: Emulates a traditional ACSI hard drive, supporting legacy Atari software with custom partitions. Requires Atari hard disk drivers.  
 
 Choose **GEMDRIVE** for convenience and modern workflows, and **ACSI** for full compatibility with vintage software.
 


### PR DESCRIPTION
## Summary
- remove the explicit HDDRIVER / ICD Pro mention from the ACSI2STM FAQ
- replace the local TOS support table in  with a link to the official upstream compatibility list
- keep the older-TOS guidance more generic
