### PR TITLE
docs: add Mega ST shielding note to riser board docs

### DIFF
--- a/acsi2stm-atari-st/riser-boards.md
+++ b/acsi2stm-atari-st/riser-boards.md
@@ -99,6 +99,13 @@ Always power the Atari off completely and disconnect it from mains power before 
 - the USB-C lead should not be sharply bent
 - the Dupont power lead should be routed away from sharp metal edges
 
+### A note about the Mega ST metal shield
+
+In some Atari Mega ST units, it may be necessary to remove the internal metal shield to make enough room for the riser board and the ACSI2STM Compact assembly. Some Mega ST machines provide enough clearance, while others do not.
+
+This does not normally apply to the Mega STE version.
+
+In practice, that shielding no longer serves much purpose today. It was mainly intended to reduce radio-frequency interference concerns that mattered more when these machines were used near television receivers and similar equipment.
 
 ### Installing the riser board in an Atari Mega STE
 

--- a/acsi2stm-atari-st/riser-boards.md
+++ b/acsi2stm-atari-st/riser-boards.md
@@ -103,7 +103,7 @@ Always power the Atari off completely and disconnect it from mains power before 
 
 In some Atari Mega ST units, it may be necessary to remove the internal metal shield to make enough room for the riser board and the ACSI2STM Compact assembly. Some Mega ST machines provide enough clearance, while others do not.
 
-This does not normally apply to the Mega STE version.
+This does not apply to the Mega STE version.
 
 In practice, that shielding no longer serves much purpose today. It was mainly intended to reduce radio-frequency interference concerns that mattered more when these machines were used near television receivers and similar equipment.
 


### PR DESCRIPTION
## Summary
- add a practical note to the riser-board documentation explaining that some Mega ST units may require removal of the internal metal shield
- clarify that some Mega ST machines have enough clearance while others do not
- note that this does not normally apply to Mega STE systems and explain the historical purpose of the shielding
