### PR TITLE
docs: include PSU chapters in left sidebar navigation

### DIFF
--- a/sidecartridge-psu/index.md
+++ b/sidecartridge-psu/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: SidecarTridge Power Supply Unit
 nav_order: 0
-nav_exclude: true
+nav_exclude: false
 toc: false
 has_toc: false
 ---

--- a/sidecartridge-usb-c-pd-psu/index.md
+++ b/sidecartridge-usb-c-pd-psu/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: SidecarTridge USB-C PD Multi-Rail Power Supply Units
 nav_order: 0
-nav_exclude: true
+nav_exclude: false
 toc: false
 has_toc: false
 ---


### PR DESCRIPTION
## Summary
- The home grid (`index.md`) lists 10 product chapters, but the left sidebar was only showing 8.
- Both `sidecartridge-psu/index.md` and `sidecartridge-usb-c-pd-psu/index.md` had `nav_exclude: true`, hiding them from the Just-the-Docs sidebar.
- Flipped both to `nav_exclude: false` so they appear alongside the other product chapters.

No structural changes (kept `layout: default` and no `has_children`, since neither section has child pages today).

## Test plan
- [ ] Build the Jekyll site locally (`bundle exec jekyll serve`) and verify both PSU entries now appear in the left navigation
- [ ] Confirm the home grid still renders the same 10 cards