### PR TITLE
docs: link retrowiki ST hard disk compilation and cross-link MultiDevice ACSI emulator

### DIFF
--- a/acsi2stm-atari-st/before-buy.md
+++ b/acsi2stm-atari-st/before-buy.md
@@ -40,6 +40,10 @@ Here goes some links with pre-created images for the ACSI mode:
 - [Image with ACSI2STM utilities](http://atarist.sidecartridge.com/acsi2stm-5.00-hd0.img)
 - [Image disk with almost 200 games](http://atarist.sidecartridge.com/1GB-GAMES.img.zip)
 - [16MB Image with ICD Pro driver](http://joo.kie.sk/?page_id=306) (After installing the image, continue with the partition as explained in this [guide](http://joo.kie.sk/?page_id=306))
+- [Best Atari ST hard disk compilation ](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988)EVER (games, demos, tools, music, etc.) [on retrowiki.es](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988) (requires registration on retrowiki.es)
+
+{: .note}
+Did you know the [SidecarTridge MultiDevice Drives Emulator](https://docs.sidecartridge.com/sidecartridge-multidevice/microfirmwares/drives_emulator/#acsi-hard-disk-emulation-experimental) can also mount these ACSI hard disk images directly from the microSD card (experimental)?
 
 {: .note}
 If the download links do not start automatically, please right-click on the link and select "Copy link address" , open a new browser tab, paste the link in the address bar, and press Enter.

--- a/sidecartridge-multidevice/microfirmwares/drives_emulator.md
+++ b/sidecartridge-multidevice/microfirmwares/drives_emulator.md
@@ -128,6 +128,11 @@ The ACSI bus ID and the starting drive letter are configured independently. This
 | **U[n]it (ACSI ID)** | Choose the ACSI bus ID reported to TOS (`0` to `7`). Default is `7`. |
 | **Dri[v]e** | Choose the starting drive letter for the first announced partition (`C:` to `P:`). Subsequent partitions take consecutive letters. |
 
+#### Suggested disk images for ACSI emulation
+
+- [Image disk with almost 200 games](http://atarist.sidecartridge.com/1GB-GAMES.img.zip)
+- [Best Atari ST hard disk compilation ](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988)EVER (games, demos, tools, music, etc.) [on retrowiki.es](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988) (requires registration on retrowiki.es)
+
 ### Floppy Drive Emulation
 
 The Floppies Emulation represents a significant enhancement to the Multi-device. With this, the Atari ST can interface with floppy images on a microSD card as though they were actual floppy disks. Here's how to get started with Floppies Emulation.


### PR DESCRIPTION
## Summary
- In `acsi2stm-atari-st/before-buy.md`, add the "Best Atari ST hard disk compilation EVER" thread on retrowiki.es to the list of pre-created ACSI images (registration required), and a note pointing readers to the SidecarTridge MultiDevice Drives Emulator's experimental ACSI hard disk emulation as another way to use those images.
- In `sidecartridge-multidevice/microfirmwares/drives_emulator.md`, add a "Suggested disk images for ACSI emulation" subsection under the experimental ACSI Hard Disk Emulation block, listing the 1GB games image and the same retrowiki compilation link.

## Test plan
- [ ] Build the docs site locally and verify both pages render correctly.
- [ ] Confirm all four links resolve (retrowiki thread, 1GB games image, drives_emulator anchor, before-buy bullet anchor).
- [ ] Check the new note on `before-buy.md` does not break the existing flow of the "Creating images for the ACSI mode" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)