### PR TITLE
docs: cross-link MultiDevice/PSU and add retrowiki ST hard disk compilation

### DIFF
--- a/acsi2stm-atari-st/before-buy.md
+++ b/acsi2stm-atari-st/before-buy.md
@@ -19,7 +19,7 @@ There is a new version of the firmware that can be used to avoid the Bad-DMA iss
 {: .warning}
 The firmware I install in the ACSI2STM devices is the latest stable version but it does not include the Bad-DMA fix. If you want to install the Bad-DMA fix firmware, you must install the PIO firmware version at your own risk.
 
-If you don't want to take the risk of the Bad-DMA issue, the [SidecarTridge MultiDevice](https://sidecartridge.com/products/sidecartridge-multidevice-atari-st/) GEMDRIVE is a good alternative. It cannot be affected by the Bad-DMA issue and it is compatible with all Atari ST models.
+If you don't want to take the risk of the Bad-DMA issue, the [SidecarTridge MultiDevice](/sidecartridge-multidevice/) GEMDRIVE is a good alternative. It cannot be affected by the Bad-DMA issue and it is compatible with all Atari ST models.
 
 ### TOS versions supported
 
@@ -29,7 +29,7 @@ We have tested the ACSI2STM device with different TOS versions and modes, but in
 
 - [Official ACSI2STM compatibility list](https://github.com/retro16/acsi2stm/blob/stable/doc/compatibility.md)
 
-If you need support for large size partitions in older TOS versions, the [SidecarTridge MultiDevice](https://sidecartridge.com/products/sidecartridge-multidevice-atari-st/) GEMDRIVE is a good alternative.
+If you need support for large size partitions in older TOS versions, the [SidecarTridge MultiDevice](/sidecartridge-multidevice/) GEMDRIVE is a good alternative.
 
 ### Creating images for the ACSI mode
 
@@ -43,7 +43,7 @@ Here goes some links with pre-created images for the ACSI mode:
 - [Best Atari ST hard disk compilation ](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988)EVER (games, demos, tools, music, etc.) [on retrowiki.es](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988) (requires registration on retrowiki.es)
 
 {: .note}
-Did you know the [SidecarTridge MultiDevice Drives Emulator](https://docs.sidecartridge.com/sidecartridge-multidevice/microfirmwares/drives_emulator/#acsi-hard-disk-emulation-experimental) can also mount these ACSI hard disk images directly from the microSD card (experimental)?
+Did you know the [SidecarTridge MultiDevice Drives Emulator](/sidecartridge-multidevice/microfirmwares/drives_emulator/#acsi-hard-disk-emulation-experimental) can also mount these ACSI hard disk images directly from the microSD card (experimental)?
 
 {: .note}
 If the download links do not start automatically, please right-click on the link and select "Copy link address" , open a new browser tab, paste the link in the address bar, and press Enter.

--- a/acsi2stm-atari-st/faq.md
+++ b/acsi2stm-atari-st/faq.md
@@ -44,7 +44,7 @@ To use GEMDRIVE units under EmuTOS and TOS 2.0x you must ensure that the **GEMDR
 
 ### Why do I need a USB-C cable?
 
-The ACSI2STM requires a USB-C cable to power the device because it cannot draw enough power from the Atari's ACSI port. The USB-C cable should be connected to a USB power source, such as a computer, USB charger, SidecarTridge Multi-device, or a USB power bank.
+The ACSI2STM requires a USB-C cable to power the device because it cannot draw enough power from the Atari's ACSI port. The USB-C cable should be connected to a USB power source, such as a computer, USB charger, [SidecarTridge Multi-device](/sidecartridge-multidevice/), or a USB power bank.
 
 ### Can I use the ACSI2STM with SidecarTridge Multi-device?
 

--- a/sidecartridge-kickstart/introduction.md
+++ b/sidecartridge-kickstart/introduction.md
@@ -117,7 +117,7 @@ The SidecarTridge Kickstart emulator is an invaluable tool for anyone seeking to
 
 ## Project Background
 
-The development of the SidecarTridge Kickstart emulator comes from the TOS Emulator for Atari ST computers, and originated from a need identified during the creation of the SidecarTridge multi-device cartridge for Atari ST. One of the significant challenges encountered was testing firmware across different ROM versions. Existing software solutions often proved unreliable, leading to a cumbersome and inefficient testing process.
+The development of the SidecarTridge Kickstart emulator comes from the TOS Emulator for Atari ST computers, and originated from a need identified during the creation of the [SidecarTridge multi-device cartridge](/sidecartridge-multidevice/) for Atari ST. One of the significant challenges encountered was testing firmware across different ROM versions. Existing software solutions often proved unreliable, leading to a cumbersome and inefficient testing process.
 
 Frustrated by the limitations of software-based testing, I decided to develop a hardware solution that could emulate the ROMs at the signal level. This led to the creation of the [SidecarTridge ROM emulator board](/sidecartridge-rom/), a device designed to replicate the functionality of the venerable 27CXXXX ROMs (and their equivalents) used in the Atari ST.
 

--- a/sidecartridge-multidevice/troubleshooting_v2.md
+++ b/sidecartridge-multidevice/troubleshooting_v2.md
@@ -33,7 +33,7 @@ If your computer randomly crashes with different error messages when the Multi-d
 
 - The Multi-device board is properly connected to the Pico W headers.
 - The Multi-device board is properly connected to the computer cartridge connector. Please verify that the board is properly inserted and aligned with the cartridge connector.
-- The Multi-device board is properly powered. Please verify that the power supply of your computer is working properly. A faulty power supply can cause random crashes and errors.
+- The Multi-device board is properly powered. Please verify that the [power supply](/sidecartridge-psu/) of your computer is working properly. A faulty power supply can cause random crashes and errors.
 - The Multi-device board is cartridge connector is clean. Please clean the cartridge connector with isopropyl alcohol.
 - The computer cartridge interface is dirty or rusty.
 

--- a/sidecartridge-tos/introduction.md
+++ b/sidecartridge-tos/introduction.md
@@ -117,7 +117,7 @@ The SidecarTridge TOS emulator is an invaluable tool for anyone seeking to maxim
 
 ## Project Background
 
-The development of the SidecarTridge TOS emulator originated from a need identified during the creation of the SidecarTridge multi-device cartridge. One of the significant challenges encountered was testing firmware across different TOS versions. Existing software solutions often proved unreliable, leading to a cumbersome and inefficient testing process.
+The development of the SidecarTridge TOS emulator originated from a need identified during the creation of the [SidecarTridge multi-device cartridge](/sidecartridge-multidevice/). One of the significant challenges encountered was testing firmware across different TOS versions. Existing software solutions often proved unreliable, leading to a cumbersome and inefficient testing process.
 
 Frustrated by the limitations of software-based testing, I decided to develop a hardware solution that could emulate the ROMs at the signal level. This led to the creation of the [SidecarTridge ROM emulator board](/sidecartridge-rom/), a device designed to replicate the functionality of the venerable 27CXXXX ROMs (and their equivalents) used in the Atari ST.
 


### PR DESCRIPTION
## Summary
- Add link to the retrowiki.es Atari ST hard disk compilation in the ACSI2STM image resources section.
- Replace external sidecartridge.com URLs and plain-text mentions of the SidecarTridge MultiDevice with internal doc links across ACSI2STM, Kickstart and TOS pages.
- Link the MultiDevice PSU page from the troubleshooting power-supply note.

## Test plan
- [ ] Build the docs site locally and confirm all updated links resolve to the expected internal pages.
- [ ] Spot-check the new retrowiki link on `acsi2stm-atari-st/before-buy.md`.