### PR TITLE
Hide Certifications from sidebar nav

### DIFF
--- a/certifications/index.md
+++ b/certifications/index.md
@@ -2,7 +2,7 @@
 layout: home
 title: Certifications
 nav_order: 0
-nav_exclude: false
+nav_exclude: true
 has_children: true
 toc: false
 has_toc: false


### PR DESCRIPTION
## Summary
- Set `nav_exclude: true` on `certifications/index.md` so the "Certifications" entry no longer appears in the docs sidebar.
- The DoC and EMC Assessment PDFs remain accessible via their direct URLs (which is how they are linked from the signed declarations themselves), and the page is already excluded from sitemap/search via `_config.yml` defaults.

## Test plan
- [ ] Build the site locally (`bundle exec jekyll serve`) and confirm "Certifications" is gone from the left sidebar.
- [ ] Verify a direct link such as `/certifications/EU-ROM-EMULATOR-REV3.0.0-DECLARATION-OF-CONFORMITY/...pdf` still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)