### PR TITLE
docs: link atari-hd from ACSI hard-disk sections

### DIFF
--- a/acsi2stm-atari-st/before-buy.md
+++ b/acsi2stm-atari-st/before-buy.md
@@ -50,7 +50,9 @@ If the download links do not start automatically, please right-click on the link
 
 Probably the fastest way to burn the images into the SD card is using the [Raspberry Pi Imager](https://www.raspberrypi.com/software/).
 
-If you want to create your own TOS & DOS compatible images, you should use to [_Atari Hard Disk and File Systems Reference Guide_](http://atarist.sidecartridge.com/atari-st-hd-file-systems-ref-guide.pdf) by Jean Louis-Guerin (DrCoolZic).
+If you want to create your own TOS & DOS compatible images, the easiest path is [`atari-hd`](https://github.com/sidecartridge/atari-hd), a multiplatform CLI/TUI (macOS, Linux, Windows) that produces a ready-to-use `.img` in one command. It walks you through size, partition layout (AHDI, PPDRIVER or HDDRIVER) and bootable mode in plain language, and the byte-level output is validated against real ICDFMT- and PPTOSDOS-formatted reference disks, so you skip the multi-evening rabbit hole of legacy tools.
+
+For the deeper background on TOS-side BPBs, sector sizes and how the partition tables differ between drivers, see the [_Atari Hard Disk and File Systems Reference Guide_](http://atarist.sidecartridge.com/atari-st-hd-file-systems-ref-guide.pdf) by Jean Louis-Guerin (DrCoolZic).
 
 ICD Pro is a free driver that can be used with ACSI devices. You can download from here: [ICD Pro](http://joo.kie.sk/?page_id=306). Then you can follow the instructions in this [guide](http://joo.kie.sk/?page_id=306).
 

--- a/acsi2stm-atari-st/user-guide.md
+++ b/acsi2stm-atari-st/user-guide.md
@@ -116,6 +116,9 @@ The formatting and partitioning tool works much like modern equivalents: format 
 {: .warning}
 Formatting the a modern SD card with a tool designed 30 years ago can be a daunting task. It is recommended to use a preconfigured image to avoid frustation and time consuming tasks.
 
+{: .note}
+If you do want to build your own image without the rabbit hole of legacy tools, [`atari-hd`](https://github.com/sidecartridge/atari-hd) is a multiplatform CLI/TUI (macOS, Linux, Windows) that produces a ready-to-use `.img` in one command. It walks you through size, partition layout (AHDI, PPDRIVER or HDDRIVER) and bootable mode in plain language, and the byte-level output is validated against real ICDFMT- and PPTOSDOS-formatted reference disks.
+
 #### TOS Issues
 
 Atari TOS has a variety of quirks and bugs. While some of these issues can be mitigated with software patches, no configuration has proven to be fully stable when scaling beyond basic use. Key limitations include:

--- a/sidecartridge-multidevice/microfirmwares/drives_emulator.md
+++ b/sidecartridge-multidevice/microfirmwares/drives_emulator.md
@@ -133,6 +133,10 @@ The ACSI bus ID and the starting drive letter are configured independently. This
 - [Image disk with almost 200 games](http://atarist.sidecartridge.com/1GB-GAMES.img.zip)
 - [Best Atari ST hard disk compilation ](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988)EVER (games, demos, tools, music, etc.) [on retrowiki.es](https://www.retrowiki.es/viewtopic.php?p=200152988#p200152988) (requires registration on retrowiki.es)
 
+#### Build your own image with `atari-hd`
+
+If you'd rather build your own bootable hard disk image instead of downloading a pre-made one, the [`atari-hd`](https://github.com/sidecartridge/atari-hd) CLI/TUI does it in a single command on macOS, Linux and Windows. Pick a size, partition layout (AHDI, PPDRIVER or HDDRIVER) and bootable mode in plain language, and you get a working `.img` ready to drop on the microSD card. The byte-level output is validated against real ICDFMT- and PPTOSDOS-formatted reference disks, so the result matches what a real Atari-era setup tool would have written, only without the multi-evening rabbit hole.
+
 ### Floppy Drive Emulation
 
 The Floppies Emulation represents a significant enhancement to the Multi-device. With this, the Atari ST can interface with floppy images on a microSD card as though they were actual floppy disks. Here's how to get started with Floppies Emulation.


### PR DESCRIPTION
## Summary

Adds a pointer to the new multiplatform [`atari-hd`](https://github.com/sidecartridge/atari-hd) builder in the two places the docs currently talk about Atari ST hard-disk images. The tool fills the "I'd rather build my own image than download one" gap, with a friendly TUI/CLI flow on macOS, Linux and Windows that produces a ready-to-flash `.img` validated byte-for-byte against real ICDFMT- and PPTOSDOS-formatted reference disks.

### Where the link is added

- **ACSI2STM user guide** (`acsi2stm-atari-st/user-guide.md`): right after the existing `.warning` block recommending a preconfigured image, a new `.note` callout points to `atari-hd` as the build-your-own alternative for users who prefer to roll their own image rather than download one.
- **md-drives-emulator microfirmware page** (`sidecartridge-multidevice/microfirmwares/drives_emulator.md`): a new `#### Build your own image with atari-hd` subsection inside the ACSI Hard Disk Emulation section, right after the suggested ready-made images list. Framed as the complement to the pre-made list rather than a replacement.

Both blurbs:
- Mention the three supported partition-table layouts: AHDI, PPDRIVER, HDDRIVER.
- Call out that the tool runs on macOS, Linux and Windows.
- Note that the byte-level output is validated against real ICDFMT- and PPTOSDOS-formatted reference disks.
- Match the surrounding docs' tone, no em dashes.

### Notes

- This is purely additive; nothing in the existing copy is changed.
- The link is the canonical repo URL; if a release page or homepage gets set up later, we can swap to that without touching the surrounding text.

## Test plan

- [ ] Render locally and confirm the two new blocks land in the expected positions (after the warning in the ACSI2STM user guide, after the suggested-images list in the Drives Emulator ACSI section).
- [ ] Click through the `https://github.com/sidecartridge/atari-hd` link from the rendered pages.
- [ ] Read once more for tone consistency with the surrounding sections.