### PR TITLE
docs(st2vga-family): embed ST2VGA Enhanced YouTube Short

### DIFF
--- a/st2vga-family/index.md
+++ b/st2vga-family/index.md
@@ -73,6 +73,16 @@ That active stage requires a stable supply, so Enhanced uses **external 5 V via 
 
 A practical bonus: Enhanced can also be used with very early ST machines that **do not provide +12 V** on the monitor connector.
 
+<figure class="video_container" style="position: relative; padding-bottom: 140%; height: 0; overflow: hidden; max-width: 420px; margin: 0 auto; background: #000;">
+  <iframe 
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"
+    src="https://www.youtube.com/embed/qtu1WBJdyQU?iv_load_policy=3&modestbranding=1&playsinline=1&showinfo=0&rel=0&enablejsapi=1"
+    loading="lazy"
+    allowfullscreen
+    allowtransparency>
+  </iframe>
+</figure>
+
 ## Which one should I buy?
 
 - Choose **ST2VGA (Rev.3)** if:


### PR DESCRIPTION
## Summary

Embeds the new ST2VGA Enhanced demo Short (`qtu1WBJdyQU`) on the `st2vga-family/index.md` page, at the end of the **"What ST2VGA Enhanced adds (and why it needs power)"** section and immediately before the **"Which one should I buy?"** decision aid. The video visually demonstrates the active conditioning stage the section text describes, so the placement is contextual to the Enhanced model.

The embed reuses the existing YouTube Shorts pattern already in use on `sidecartridge-multidevice/microfirmwares/gpu-demo.md`:

- `<figure class="video_container">` with `padding-bottom: 140%` for the 9:16 Shorts aspect ratio.
- `max-width: 420px` so the player does not stretch on wide layouts.
- Iframe with `loading="lazy"`, `modestbranding=1`, `rel=0`, `playsinline=1`, `iv_load_policy=3`, `showinfo=0`, `enablejsapi=1`. Same parameter set as the existing embeds.

No other content changes.

## Test plan

- [ ] Render locally / preview on Netlify and confirm the Short renders correctly between the Enhanced description and the decision section.
- [ ] Verify the player respects the 9:16 frame and lazy-loads on scroll.
- [ ] Spot-check the existing GPU Demo Short still renders correctly (regression check on the shared pattern).