### PR TITLE
docs(kickstart): document 256KB to 512KB mirror requirement

### DIFF
--- a/sidecartridge-kickstart/before-buy.md
+++ b/sidecartridge-kickstart/before-buy.md
@@ -92,6 +92,17 @@ Select the kit that matches your motherboard revision.
 | [A2000 carrier rev4.3 and later](https://store.sidecartridge.com) | A2000 rev4.3 and later |
 
 
+## Notes on Kickstart ROM sources
+
+The emulator targets the 512KB Kickstart ROM socket and expects the active image to be exactly 524288 bytes (512KB). Most Kickstart 2.04 and later images, as well as DiagROM and EmuTOS, are already 512KB and can be copied directly to `ROMEMUL`.
+
+If you plan to use a Kickstart 1.x image (1.1, 1.2, 1.3), be aware that those originals are 256KB. Real Amiga motherboards mirror them into the 512KB socket natively, but the SidecarTridge Kickstart emulator does not. Before copying a 256KB Kickstart to the device you must mirror it to 512KB:
+
+- From an Amiga Forever encrypted source, the [web converter](/sidecartridge-kickstart/kickstart-conversion/) does the mirror automatically.
+- From a plain 256KB dump, you mirror the file yourself with one of the snippets in [Already-decoded Kickstart ROMs](/sidecartridge-kickstart/kickstart-conversion/#already-decoded-kickstart-roms).
+
+This is a one-time, one-command step per ROM. It is mentioned here because it is the most common surprise for users coming from the Kickstart 1.x era.
+
 ## Notes on motherboard identification
 
 The revision tables above were created using multiple hardware references, including:

--- a/sidecartridge-kickstart/compatibility.md
+++ b/sidecartridge-kickstart/compatibility.md
@@ -53,15 +53,30 @@ If your motherboard revision is not listed, or if you are unsure whether the ROM
 
 ## Kickstart and custom ROM compatibility
 
-The SidecarTridge Kickstart emulator targets the classic Amiga 512KB Kickstart ROM series and also runs custom ROMs such as DiagROM or EmuTOS. If you use Cloanto/Amiga Forever images, convert them with the [Kickstart ROM conversion guide](/sidecartridge-kickstart/kickstart-conversion/).
+The SidecarTridge Kickstart emulator targets the classic Amiga 512KB Kickstart ROM socket and also runs custom ROMs such as DiagROM or EmuTOS. If you use Cloanto/Amiga Forever images, convert them with the [Kickstart ROM conversion guide](/sidecartridge-kickstart/kickstart-conversion/).
 
-| ROM image | Size (KB) | Tested | Works | Notes |
-|-----------|-----------|--------|-------|-------|
+### ROM image size requirements
+
+The emulator presents a single 512KB ROM image to the Amiga. Every file copied to `ROMEMUL` and selected via `DEFAULT.TXT`/`RESCUE.TXT` (or SWITCHER) must therefore be **exactly 524288 bytes (512KB)**.
+
+Original Kickstart 1.x and early 2.x images are 256KB on real hardware because the original Amiga motherboards mirror those 256KB into the 512KB address space natively. The SidecarTridge Kickstart emulator does not perform that mirror in firmware, so 256KB Kickstart images must be doubled (mirrored to 512KB) in software before they can be used. This is by design and will not change in future firmware releases.
+
+There are two ways to obtain a 512KB image from a 256KB Kickstart source:
+
+- **Encrypted Amiga Forever image (AMIROMTYPE1)**: use the [web converter](/sidecartridge-kickstart/kickstart-conversion/). When the decoded payload is 256KB or smaller, the converter automatically pads it to 256KB and duplicates the block, returning a ready-to-use 512KB file.
+- **Already-decoded plain 256KB ROM dump**: the converter does not accept this kind of file. Duplicate the ROM manually before copying it to `ROMEMUL`. See [Already-decoded Kickstart ROMs](/sidecartridge-kickstart/kickstart-conversion/#already-decoded-kickstart-roms) for the exact `cat` and PowerShell snippets.
+
+Files that are not exactly 512KB on `ROMEMUL` will either be ignored by the device or boot to a hang/black screen on the Amiga, depending on the actual size. If you see that behaviour, check the byte count of the file first.
+
+### Tested ROM images
+
+| ROM image | Native size (KB) | Tested | Works | Notes |
+|-----------|------------------|--------|-------|-------|
 | Kickstart 0.7 | 256 | Yes | No | Fails to boot properly on the emulator |
 | Kickstart 1.0 | 256 | Yes | No | Fails to boot properly on the emulator |
-| Kickstart 1.1 | 256 | Yes | Yes | OK |
-| Kickstart 1.2 (33.180) | 256 | Yes | Yes | OK |
-| Kickstart 1.3 (34.5) | 256 | Yes | Yes | OK |
+| Kickstart 1.1 | 256 | Yes | Yes | Must be mirrored to 512KB before use |
+| Kickstart 1.2 (33.180) | 256 | Yes | Yes | Must be mirrored to 512KB before use |
+| Kickstart 1.3 (34.5) | 256 | Yes | Yes | Must be mirrored to 512KB before use |
 | Kickstart 2.04 (37.175) | 512 | Yes | Yes | OK |
 | Kickstart 2.05 | 512 | Yes | Yes | OK |
 | Kickstart 3.0 | 512 | Yes | Yes | OK |

--- a/sidecartridge-kickstart/faq.md
+++ b/sidecartridge-kickstart/faq.md
@@ -26,7 +26,7 @@ Potentially, if a carrier board exists for that ROM socket and the board uses a 
 
 ### Which Kickstart sizes are supported?
 
-Classic 256KB Kickstart 1.x/early 2.x images and 512KB Kickstart 2.04/2.05/3.x images are supported. Custom ROMs like DiagROM/EmuTOS that use the same pinout and size also work.
+Classic 256KB Kickstart 1.x/early 2.x images and 512KB Kickstart 2.04/2.05/3.x images are supported, plus custom ROMs like DiagROM and EmuTOS that use the same pinout and 512KB layout. The emulator always presents a 512KB ROM to the Amiga, so 256KB Kickstarts must be mirrored to 512KB before being copied to `ROMEMUL`. See the [Compatibility](/sidecartridge-kickstart/compatibility/#rom-image-size-requirements) and [Kickstart conversion](/sidecartridge-kickstart/kickstart-conversion/) pages for details.
 
 ### Why is the SidecarTridge Kickstart limited to 16MB of flash storage?
 
@@ -80,6 +80,18 @@ Standard updates do not overwrite your stored images. As a best practice, keep a
 ### How do I switch between Kickstart versions?
 
 Use the SWITCHER application from the `ROMEMUL` volume on your Amiga, or edit `DEFAULT.TXT`/`RESCUE.TXT` over USB and eject to reindex. See the [User Guide](/sidecartridge-kickstart/user-guide/) for details.
+
+### My Kickstart 1.3 file is 256KB. Can I just copy it to `ROMEMUL`?
+
+No. The emulator presents a 512KB ROM to the Amiga, and a plain 256KB file will not boot. Original Amiga motherboards mirror 256KB Kickstarts into the 512KB socket natively, but the emulator does not, so the file has to be doubled before use. If your source is an Amiga Forever encrypted image, the [web converter](/sidecartridge-kickstart/kickstart-conversion/) does the mirror automatically. If your file is already a plain 256KB ROM, duplicate it manually as described in [Already-decoded Kickstart ROMs](/sidecartridge-kickstart/kickstart-conversion/#already-decoded-kickstart-roms), then copy the resulting 512KB file to `ROMEMUL`.
+
+### The web converter says "not an AMIROMTYPE1 encoded image". What does that mean?
+
+That error is shown when the file you uploaded does not start with the `AMIROMTYPE1` header used by Amiga Forever encrypted ROMs. The converter is only for those encrypted images. If your file is already a plain ROM (for example a personal chip dump or a download from a non-Amiga-Forever source), do not use the converter; follow the [Already-decoded Kickstart ROMs](/sidecartridge-kickstart/kickstart-conversion/#already-decoded-kickstart-roms) instructions instead.
+
+### Why does my 256KB Kickstart boot to a black screen or a hang?
+
+Because the file on `ROMEMUL` is still 256KB. The emulator expects exactly 524288 bytes (512KB), so the Amiga reads garbage in the second half of the ROM space and fails to come up. Mirror the file to 512KB (either via the [web converter](/sidecartridge-kickstart/kickstart-conversion/) for encrypted sources or with `cat`/PowerShell for plain dumps) and copy the 512KB result to `ROMEMUL`.
 
 [Previous: Troubleshooting](/sidecartridge-kickstart/troubleshooting/){: .btn .mr-4 }
 [Main](/sidecartridge-kickstart/){: .btn .mr-4 }

--- a/sidecartridge-kickstart/getting-started.md
+++ b/sidecartridge-kickstart/getting-started.md
@@ -120,6 +120,15 @@ The SidecarTridge Kickstart emulator uses a FAT12 file system with a 4KBytes clu
 
 To copy ROM image files to the SidecarTridge Kickstart emulator, drag and drop them into the `ROMEMUL` volume. The emulator will automatically store the ROM images in the file system.
 
+### ROM image size requirements
+
+The emulator presents a single 512KB ROM image to the Amiga. Every file copied to `ROMEMUL` and selected as the active or rescue image must therefore be **exactly 524288 bytes (512KB)**.
+
+- Kickstart 2.04 and later, DiagROM, EmuTOS and most modern custom ROMs are already 512KB. Copy them directly.
+- Kickstart 1.1, 1.2, 1.3 and other early 256KB Kickstarts must be mirrored to 512KB before being copied to `ROMEMUL`. Real Amiga motherboards mirror those 256KB into the 512KB ROM socket natively, but the SidecarTridge Kickstart emulator does not, so the user has to do it once on the file. This is by design.
+
+If your source is an Amiga Forever encrypted image (`AMIROMTYPE1`), the [web converter](/sidecartridge-kickstart/kickstart-conversion/) takes care of the mirror automatically when needed. If your source is already a plain 256KB ROM dump, follow the manual mirroring instructions in [Already-decoded Kickstart ROMs](/sidecartridge-kickstart/kickstart-conversion/#already-decoded-kickstart-roms) before continuing with this section.
+
 ### Copying ROM Image Files
 
 Before copying ROM image files to the SidecarTridge Kickstart emulator, it is strongly recommended to first copy all files to a folder on your computer. This way, you can easily restore them if needed.

--- a/sidecartridge-kickstart/kickstart-conversion.md
+++ b/sidecartridge-kickstart/kickstart-conversion.md
@@ -49,6 +49,41 @@ To begin the conversion process, first drag and drop or select multiple Kickstar
 
 Once the files are uploaded press the "DECODE & DOWNLOAD" button. The tool will decode the encoded ROM files using the provided key and package all the converted ROM files into a single ZIP archive for easy download. If any errors occur during the conversion process, they will be displayed in the "Errors" section of the tool. If only one file is uploaded, the tool will provide the converted ROM file directly for download without packaging it into a ZIP archive.
 
+## What the converter does (and does not do)
+
+The web converter is built exclusively for Amiga Forever images that carry the `AMIROMTYPE1` header. For each uploaded file it:
+
+1. Verifies the `AMIROMTYPE1` header at the start of the file. Files without that header are rejected with a `not an AMIROMTYPE1 encoded image` error.
+2. XOR-decodes the payload using the bytes from `rom.key`, cycling through the key as needed.
+3. **Auto-mirrors small ROMs**. If the decoded payload is 256KB or smaller, the converter pads it to 256KB with zeros and then duplicates the block, returning a 512KB image that the emulator can use as-is.
+4. **Leaves larger ROMs as-is**. If the decoded payload is larger than 256KB (the typical 512KB Kickstart 2.04, 2.05, 3.0, 3.1 case), the output is the decoded data without padding or duplication.
+
+The mirror behaviour matches what real Amiga motherboards do natively when they map a 256KB Kickstart into a 512KB ROM socket. The SidecarTridge Kickstart emulator does not perform that mirror in firmware, so the converter does it for you when it can.
+
+## Already-decoded Kickstart ROMs
+
+The web converter is not the right tool if your Kickstart ROM is already a plain (decrypted) `.rom` or `.img` file, for example a personal chip dump or a file you obtained outside Amiga Forever. The converter will reject anything that does not start with the `AMIROMTYPE1` header.
+
+Handle these images directly:
+
+- **Plain 512KB ROM** (Kickstart 2.04 and later, custom ROMs such as DiagROM or EmuTOS): copy the file directly to the `ROMEMUL` volume and set `DEFAULT.TXT` to its filename. No conversion is needed.
+- **Plain 256KB ROM** (Kickstart 1.1, 1.2, 1.3 and similar): the image must be mirrored to 512KB before being copied to `ROMEMUL`. The emulator does not auto-mirror on boot; this is by design. Duplicate the file with one of the following one-liners:
+
+  ```bash
+  # macOS or Linux
+  cat kick13.rom kick13.rom > kick13_512kb.rom
+  ```
+
+  ```powershell
+  # Windows PowerShell
+  $bytes = [IO.File]::ReadAllBytes('kick13.rom')
+  [IO.File]::WriteAllBytes('kick13_512kb.rom', $bytes + $bytes)
+  ```
+
+  The resulting `kick13_512kb.rom` will be exactly 524288 bytes (512KB) and contain the original ROM twice back to back, matching the layout the emulator expects.
+
+After mirroring, copy `kick13_512kb.rom` to `ROMEMUL` and set `DEFAULT.TXT` (or use SWITCHER) to point at the 512KB file, not the original 256KB one.
+
 ## Next Steps
 
 After downloading the converted Kickstart ROM files, you can proceed to copy them to the SidecarTridge Kickstart emulator's storage. Follow the instructions in the [Getting Started](https://docs.sidecartridge.com/sidecartridge-kickstart/getting-started/) section of the documentation to learn how to transfer the ROM files and configure the emulator for use with your Commodore Amiga 500/2000.

--- a/sidecartridge-kickstart/troubleshooting.md
+++ b/sidecartridge-kickstart/troubleshooting.md
@@ -80,6 +80,18 @@ Check these items:
 
 Some USB cables can assert signals that interfere with the emulator. Fully unplug the USB cable from the SidecarTridge Kickstart board and try again.
 
+### The Amiga hangs or shows a black screen with a 256KB Kickstart (1.x / early 2.x)
+
+The emulator presents a 512KB ROM image to the Amiga and does not auto-mirror 256KB images at boot. Original Amiga motherboards mirror 256KB Kickstarts into the 512KB socket natively, but the SidecarTridge Kickstart emulator does not, so a 256KB file on `ROMEMUL` produces an invalid second half and the Amiga either hangs with no output or shows random garbage.
+
+To fix it:
+
+1. Check the size of the file on `ROMEMUL`. It must be exactly **524288 bytes (512KB)**.
+2. If it is 256KB (262144 bytes), the file needs to be mirrored to 512KB.
+   - For Amiga Forever encrypted sources, run the file through the [web converter](/sidecartridge-kickstart/kickstart-conversion/). It auto-mirrors small ROMs.
+   - For plain 256KB dumps, duplicate the file manually with the snippets in [Already-decoded Kickstart ROMs](/sidecartridge-kickstart/kickstart-conversion/#already-decoded-kickstart-roms).
+3. Replace the 256KB file on `ROMEMUL` with the new 512KB one, update `DEFAULT.TXT` (or use SWITCHER) to point at the 512KB filename, and eject the volume so the device reindexes.
+
 ## SWITCHER issues
 
 ### The SWITCHER program returns an error when reading available images

--- a/sidecartridge-kickstart/user-guide.md
+++ b/sidecartridge-kickstart/user-guide.md
@@ -103,6 +103,9 @@ It is possible to upload, delete and rename a new ROM image from any Amiga compu
 
 ### Uploading a new ROM from the Amiga computer
 
+{: .note}
+Before uploading via SWITCHER, make sure the ROM image is exactly 512KB (524288 bytes). The emulator does not auto-mirror 256KB Kickstart images, so 256KB originals must be doubled to 512KB on your host computer first. See [ROM image size requirements](/sidecartridge-kickstart/compatibility/#rom-image-size-requirements) and [Kickstart conversion](/sidecartridge-kickstart/kickstart-conversion/) for the exact procedure.
+
 To upload a new Kickstart or custom ROM image from the Amiga computer, press the [`U`]pload key in the SWITCHER program. The program will show you a file system browser to select the ROM image to upload from your computer. Navigate to the desired ROM image and press the `RETURN` key to start the upload process.
 
 {: .warning}


### PR DESCRIPTION
## Summary

The SidecarTridge Kickstart emulator presents a single 512KB ROM image to the Amiga and does not auto-mirror 256KB Kickstart 1.x / early 2.x images at boot, even though real Amiga motherboards mirror those 256KB Kickstarts into the 512KB ROM socket natively. Plain 256KB Kickstart files therefore hang or boot to a black screen on the Amiga unless the user doubles them to 512KB beforehand.

The current documentation does not make this clear. In particular, `compatibility.md` lists Kickstart 1.1/1.2/1.3 as "OK" without flagging the manual mirroring step, and `kickstart-conversion.md` only covers the Amiga Forever (encrypted) path.

This PR updates the Kickstart documentation so the requirement is explained clearly and consistently across the pages a user is most likely to land on.

## Changes

- `compatibility.md`: add a "ROM image size requirements" section and reword the tested-images table notes so Kickstart 1.x rows reflect the mirroring requirement instead of implying they work as-is.
- `kickstart-conversion.md`: document exactly what the web converter does (AMIROMTYPE1-only, XOR decode, auto-mirror when the decoded payload is 256KB or smaller) and add an "Already-decoded Kickstart ROMs" section with `cat` / PowerShell snippets for manual 256KB to 512KB mirroring.
- `getting-started.md`: add a "ROM image size requirements" subsection before the ROM copy procedure.
- `faq.md`: add entries covering 256KB copies, the AMIROMTYPE1 error message and the black-screen / hang symptom; reword the existing "Which Kickstart sizes are supported?" answer to flag the mirror.
- `troubleshooting.md`: add a dedicated entry for the 256KB hang / black screen symptom with step-by-step recovery.
- `user-guide.md`: add a note before the SWITCHER upload section so users do not upload an unmirrored 256KB file from the Amiga side.
- `before-buy.md`: add a "Notes on Kickstart ROM sources" section so buyers who already own 256KB dumps know about the manual step before purchase.

All cross-links point at the same canonical anchors so the user can land on any of these pages and reach the workaround in one click.

## Test plan

- [ ] Render the seven changed pages and confirm the new sections appear with working anchors.
- [ ] Verify the `cat` and PowerShell snippets produce a 524288-byte file from a 262144-byte Kickstart 1.3 sample.
- [ ] Cross-check the table notes in `compatibility.md` against the Kickstart conversion guide so the wording stays consistent.