### PR TITLE
docs(kickstart): fix misleading carrier names, Atari ST leftovers and FAT mismatch

### DIFF
--- a/sidecartridge-kickstart/before-buy.md
+++ b/sidecartridge-kickstart/before-buy.md
@@ -81,15 +81,14 @@ Incorrect desoldering can permanently damage the motherboard.
 
 ## Step 4 — Choose the correct emulator kit
 
-Select the kit that matches your motherboard revision.
+Select the kit that matches your motherboard revision. The A500 family is covered by two kits, and the A2000 family by another two.
 
 | SidecarTridge Kickstart Emulator Kit | Supported boards |
 |--------------------------------------|-----------------|
-| [A500 rev3](https://store.sidecartridge.com) | A500 rev3 |
-| [A500 rev5](https://store.sidecartridge.com) | A500 rev5 |
-| [A500 rev6a](https://store.sidecartridge.com) | A500 rev6a |
+| [A500 carrier rev5 and earlier](https://store.sidecartridge.com) | A500 rev3, A500 rev5 |
+| [A500 carrier rev6 and later](https://store.sidecartridge.com)   | A500 rev6a |
 | [A2000 carrier rev4.2 and earlier](https://store.sidecartridge.com) | A2000 rev4.2 and earlier |
-| [A2000 carrier rev4.3 and later](https://store.sidecartridge.com) | A2000 rev4.3 and later |
+| [A2000 carrier rev4.3 and later](https://store.sidecartridge.com)   | A2000 rev4.3 and later |
 
 
 ## Notes on Kickstart ROM sources

--- a/sidecartridge-kickstart/compatibility.md
+++ b/sidecartridge-kickstart/compatibility.md
@@ -45,8 +45,8 @@ Carrier boards for additional Amiga models are in active development. Check the 
 
 | Motherboard revision | ROM socket layout | Carrier board / kit | Status |
 |----------------------|-------------------|---------------------|--------|
-| A2000 rev4.2 and earlier | Single 512KB Kickstart socket | A500-family carrier board | Supported |
-| A2000 rev4.3 and later   | Single 512KB Kickstart socket | A500-family carrier board | Supported |
+| A2000 rev4.2 and earlier | Single 512KB Kickstart socket | A2000 carrier rev4.2 and earlier | Supported |
+| A2000 rev4.3 and later   | Single 512KB Kickstart socket | A2000 carrier rev4.3 and later | Supported |
 
 {: .warning}
 If your motherboard revision is not listed, or if you are unsure whether the ROM is socketed, please contact us before purchasing or installing the emulator.

--- a/sidecartridge-kickstart/compatibility.md
+++ b/sidecartridge-kickstart/compatibility.md
@@ -34,9 +34,9 @@ Carrier boards for additional Amiga models are in active development. Check the 
 
 | Motherboard revision | ROM socket layout | Carrier board / kit | Status |
 |----------------------|-------------------|---------------------|--------|
-| A500 rev3            | Single 512KB Kickstart socket | A500 rev3 kit | Supported |
-| A500 rev5            | Single 512KB Kickstart socket | A500 rev5 kit | Supported |
-| A500 rev6a           | Single 512KB Kickstart socket | A500 rev6a kit | Supported |
+| A500 rev3            | Single 512KB Kickstart socket | A500 carrier rev5 and earlier | Supported |
+| A500 rev5            | Single 512KB Kickstart socket | A500 carrier rev5 and earlier | Supported |
+| A500 rev6a           | Single 512KB Kickstart socket | A500 carrier rev6 and later | Supported |
 
 ### Amiga 2000 family
 

--- a/sidecartridge-kickstart/faq.md
+++ b/sidecartridge-kickstart/faq.md
@@ -65,7 +65,7 @@ No. You need a socketed ROM position. If your ROM is soldered, have a technician
 
 ### Which carrier board should I order?
 
-Match the carrier to your motherboard revision. The A500 family uses three dedicated kits (A500 rev3, A500 rev5, A500 rev6a), and the Amiga 2000 uses one of two dedicated carriers depending on the motherboard revision (A2000 carrier rev4.2 and earlier, or A2000 carrier rev4.3 and later). See [Before You Buy](/sidecartridge-kickstart/before-buy/) and [Compatibility](/sidecartridge-kickstart/compatibility/) for the full list.
+Match the carrier to your motherboard revision. The A500 family is covered by two kits: `A500 carrier rev5 and earlier` (for A500 rev3 and rev5 motherboards) and `A500 carrier rev6 and later` (for A500 rev6a motherboards). The Amiga 2000 has two dedicated carriers depending on the motherboard revision: `A2000 carrier rev4.2 and earlier` and `A2000 carrier rev4.3 and later`. See [Before You Buy](/sidecartridge-kickstart/before-buy/) and [Compatibility](/sidecartridge-kickstart/compatibility/) for the full list.
 
 ## Software Questions
 

--- a/sidecartridge-kickstart/faq.md
+++ b/sidecartridge-kickstart/faq.md
@@ -65,7 +65,7 @@ No. You need a socketed ROM position. If your ROM is soldered, have a technician
 
 ### Which carrier board should I order?
 
-Match the carrier to your motherboard revision: A500 rev3/rev5/rev6a each have their own kit; the A2000 Kickstart socket uses the A500-family carrier. See [Compatibility](/sidecartridge-kickstart/compatibility/).
+Match the carrier to your motherboard revision. The A500 family uses three dedicated kits (A500 rev3, A500 rev5, A500 rev6a), and the Amiga 2000 uses one of two dedicated carriers depending on the motherboard revision (A2000 carrier rev4.2 and earlier, or A2000 carrier rev4.3 and later). See [Before You Buy](/sidecartridge-kickstart/before-buy/) and [Compatibility](/sidecartridge-kickstart/compatibility/) for the full list.
 
 ## Software Questions
 

--- a/sidecartridge-kickstart/getting-started.md
+++ b/sidecartridge-kickstart/getting-started.md
@@ -71,7 +71,7 @@ The SidecarTridge Kickstart emulator does not come with Kickstart image files du
 
 When you receive your SidecarTridge Kickstart emulator kit, carefully unbox and inspect the components to ensure everything is included and in good condition. All kits should contain the following items:
 
-1. **SidecarTridge ROM Emulator Board soldered onto the Carrier Board**: This is the main component that will replace the ROM chips on your Atari ST motherboard.
+1. **SidecarTridge ROM Emulator Board soldered onto the Carrier Board**: This is the main component that will replace the Kickstart ROM chip on your Amiga motherboard.
 2. **RESCUE cable and push button**: This cable allows you to connect an external push button to the SidecarTridge Kickstart emulator for entering rescue mode.
 
 The board and the sticker on the box contain a QR code that links to the SidecarTridge Kickstart documentation website, providing access to the quickstart, user guide, compatibility information, and other resources.
@@ -87,7 +87,7 @@ As a rule of thumb, **ALWAYS** eject the `ROMEMUL` volume after making any chang
 
 ### Connecting the Device to a Computer
 
-The SidecarTridge Kickstart emulator has two modes: mass storage mode for transferring Kickstart image files and ROM emulation mode for booting the Atari ST with the selected Kickstart image. This section focuses on mass storage mode.
+The SidecarTridge Kickstart emulator has two modes: mass storage mode for transferring Kickstart image files and ROM emulation mode for booting the Amiga with the selected Kickstart image. This section focuses on mass storage mode.
 
 To enter mass storage mode, plug the SidecarTridge Kickstart emulator into the USB-C cable and connect it to your computer. It can be connected to both the Amiga and your computer simultaneously but will enter mass storage mode when powered on from the USB-C cable.
 
@@ -149,7 +149,7 @@ With the ROM image files organized and renamed, you can proceed to copy them to 
 
 #### Copying the ROM Images on macOS
 
-You can simply drag and drop the ROM image files from the `ROM Images` folder to the `ROMEMUL` volume. The files will be copied to the emulator's storage space and will be accessible for booting the Atari ST with the selected ROM image.
+You can simply drag and drop the ROM image files from the `ROM Images` folder to the `ROMEMUL` volume. The files will be copied to the emulator's storage space and will be accessible for booting the Amiga with the selected ROM image.
 
 When dragging and dropping files from a Mac to the SidecarTridge Kickstart emulator, macOS creates temporary hidden files that are not supported by the SidecarTridge Kickstart emulator. To avoid this, it is recommended to open a Terminal window to copy the files to the SidecarTridge Kickstart emulator.
 

--- a/sidecartridge-kickstart/introduction.md
+++ b/sidecartridge-kickstart/introduction.md
@@ -67,7 +67,7 @@ In summary, the SidecarTridge Kickstart emulator is designed to make Kickstart m
 
 1. **Bit-Banged Emulation**: Leveraging the powerful Programmable Input Output (PIO) features of the Raspberry RP2040 and RP235x, the SidecarTridge ROM emulator board emulates the internal ROMs of the Amiga 512KB ROM series through bit-banged emulation, eliminating the need for custom firmware or complex hardware.
 
-2. **Multi-Kickstart Version Support**: With 16MB of flash memory allows users to store and access up to 32 different Kickstart versions without requiring physical ROM swaps.
+2. **Multi-Kickstart Version Support**: With 16MB of flash memory, users can store dozens of 256KB and 512KB Kickstart images and custom ROMs and switch between them without requiring physical ROM swaps.
 
 3. **Custom ROM Support**: The emulator can run any ROM image file, including custom ROMs and open-source replacements like [EmuTOS](https://emutos.sourceforge.io/) or diagnose ROMs like [DiagROM](https://diagrom.com/). This enables users to experiment with various firmware options and enhance the functionality of the Amiga.
 
@@ -131,7 +131,7 @@ The SidecarTridge Kickstart emulator comprises several key components, each play
 
 1. **[SidecarTridge ROM Emulator Board](/sidecartridge-rom/)**: This is the core of the SidecarTridge Kickstart emulator. It leverages the Programmable Input Output (PIO) features of the Raspberry RP2040 and RP235x to emulate a ROM chip at the signal level. This board houses the necessary circuitry and flash memory to store multiple custom ROMs, provides the interface for USB connectivity, and communicates with the Amiga bus through TTL (5 volts)to CMOS (3.3 Volts) bus level shifters.
 
-2. **SidecarTridge Amiga Model Carrier Board**: The carrier boards are designed to fit seamlessly into A500 and A200 Amiga computers. It connects the ROM emulator board to the Amiga bus, allowing the emulator to communicate with the motherboard and provide the necessary signals transparently. The current versions of the carrier boards are designed to fit the Amiga A500 and A2000.
+2. **SidecarTridge Amiga Model Carrier Board**: The carrier boards are designed to fit seamlessly into A500 and A2000 Amiga computers. It connects the ROM emulator board to the Amiga bus, allowing the emulator to communicate with the motherboard and provide the necessary signals transparently. The current versions of the carrier boards are designed to fit the Amiga A500 and A2000.
 
 3. **USB Cable (Optional)**: A standard USB-C cable is needed to connect the SidecarTridge ROM emulator board to a computer. This connection is used for transferring ROM image files and custom ROMs to the emulator, making it appear as a mass storage device for easy file management. The USB cable also provides power to the emulator during the firmware update process and file transfer. 
 
@@ -153,7 +153,7 @@ The emulator leverages the PIO capabilities of the Raspberry RP2040 and RP235x m
 
 The Flash memory is a non-volatile memory that stores up to 16MB of data. This memory is used to store the ROM image files, the metadata of the ROM image files and the firmware of the device.
 
-Users can connect the emulator to a computer via USB to manage ROM files. The emulator appears as a FAT16 mass storage device, allowing users to easily copy ROM image files. This USB interface simplifies the process of updating and switching ROMs without physically interacting with the Amiga’s internals. The file system has been enhanced to provide information about the status of the emulator and the installed ROMs, as well as the ability to modify the default and rescue ROMs.
+Users can connect the emulator to a computer via USB to manage ROM files. The emulator appears as a FAT12 mass storage device, allowing users to easily copy ROM image files. This USB interface simplifies the process of updating and switching ROMs without physically interacting with the Amiga’s internals. The file system has been enhanced to provide information about the status of the emulator and the installed ROMs, as well as the ability to modify the default and rescue ROMs.
 
 ### Hot Swapping the ROMs from the Amiga
 


### PR DESCRIPTION
## Summary

Follow-up to #57. An audit pass on the Kickstart docs surfaced concrete inaccuracies that can mislead buyers or contradict the rest of the documentation. This PR fixes them and only them; structural rewrites and typo polish are left for follow-up PRs so this one stays small and easy to review.

## Changes

- **`compatibility.md`** (A2000): the A2000 rows listed the carrier as `A500-family carrier board`. The Amiga 2000 actually ships with two dedicated SKUs (`A2000 carrier rev4.2 and earlier`, `A2000 carrier rev4.3 and later`).
- **`compatibility.md`** (A500): the three rows pointed at three separate kits (rev3, rev5, rev6a). In reality the A500 family is covered by two kits: `A500 carrier rev5 and earlier` (for rev3 and rev5) and `A500 carrier rev6 and later` (for rev6a). The motherboard rows now point at the correct shared kit.
- **`before-buy.md`** (Step 4): the kit table listed three A500 SKUs as separate kits. Collapsed to the two real A500 kits and listed the supported motherboards alongside each one.
- **`faq.md`** (Which carrier should I order?): rewritten to describe two A500 kits and two A2000 kits with their motherboard coverage, cross-linking `before-buy.md` and `compatibility.md`.
- **`getting-started.md`**: three sentences in the main flow referred to the host machine as the `Atari ST` (`replace the ROM chips on your Atari ST motherboard` / `booting the Atari ST with the selected Kickstart image` / `accessible for booting the Atari ST`). Replaced with `Amiga` throughout. These were copy-paste leftovers from the TOS Emulator docs.
- **`introduction.md`** (FAT16): the USB section claimed the device appears as a `FAT16 mass storage device`, contradicting `getting-started.md` and `faq.md` which document FAT12 with a 4 KB cluster size. Aligned with the rest of the docs.
- **`introduction.md`** (A200): typo `A500 and A200 Amiga computers` corrected to `A500 and A2000`.
- **`introduction.md`** (32 versions): the "Multi-Kickstart Version Support" bullet claimed `up to 32 different Kickstart versions`, which conflicts with the FAQ wording (`dozens of 256-512KB images`). Reworded to match.

## Test plan

- [ ] Render the changed pages and confirm the new wording reads cleanly in the navigation flow.
- [ ] Verify that `before-buy.md`, `compatibility.md` and `faq.md` now name the same four canonical kits (two A500, two A2000) and that the supported-board mappings line up across the three pages.
- [ ] Grep the page texts for any remaining `Atari ST` / `FAT16` / `A200 ` / `A500-family carrier` strings under `sidecartridge-kickstart/`.