### PR TITLE
docs(tos): fix navigation, mislabeled column, FAT16 mismatch and copy-paste leftovers

### DIFF
--- a/sidecartridge-tos/before-buy.md
+++ b/sidecartridge-tos/before-buy.md
@@ -40,9 +40,9 @@ Once you have verified the compatibility of your Atari ST motherboard, you can p
 | SidecarTridge TOS Emulator Kit | Supported Motherboards           | Number of ROMs |
 |--------------------------------|----------------------------------|----------------|
 | [ST+ and STM Kit C070243](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=50843742339405)           | C070243 | 6              |
-| [STF and STFM Kit C070523](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=52498340741453)           | 070523 | 6              |
-| [STF and STFM Kit C070789 C103175 C103414](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=48912746217805)           | 070789-001, C103175-001, C103414-001 | 2              |
-| [STF and STFM Kit C070789 C103175 C103414](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=49130525098317)           | 070789-001, C103175-001, C103414-001 | 6              |
+| [STF and STFM Kit C070523](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=52498340741453)           | C070523 | 6              |
+| [STF and STFM Kit C070789 C103175 C103414](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=48912746217805)           | C070789-001, C103175-001, C103414-001 | 2              |
+| [STF and STFM Kit C070789 C103175 C103414](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=49130525098317)           | C070789-001, C103175-001, C103414-001 | 6              |
 | [STE Kit](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=48912746250573)                    | CA4003290                        | 2              |
 | [Mega ST Kit](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=49130525131085)               | C103544-001, C103277, C100167, C100501                 |       2        | 
 | [Mega STE Kit](https://store.sidecartridge.com/products/sidecartridge%C2%AE-tos-emulator-for-atari-st-e-and-megast-ste?variant=48912746283341)               | CA400677                         | 2              |

--- a/sidecartridge-tos/changelog.md
+++ b/sidecartridge-tos/changelog.md
@@ -111,7 +111,7 @@ First production release of the SWITCHER.TOS app.
 ## Hardware Changelog (ROM Emulator)
 
 ### 3.0.0 (2025-06-01) - v3 release
-This hardware release is the first stable release of the SidecarTridge Kickstart v3 board with the RP2350 microcontroller. It includes several new features and improvements over the previous versions:
+This hardware release is the first stable release of the SidecarTridge ROM Emulator v3 board with the RP2350 microcontroller. It includes several new features and improvements over the previous versions:
 - The board is now based on the RP2350 microcontroller, which provides more features and better performance.
 - The board now supports 512KB ROMs.
 - The board includes three LED indicators: a red LED that lights up when the board is powered on, a green LED that lights up when the firmware is running, and an orange LED that lights up when the internal USB drive is mounted or transferring data.

--- a/sidecartridge-tos/compatibility.md
+++ b/sidecartridge-tos/compatibility.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Compatbility
+title: Compatibility
 nav_order: 7
 nav_exclude: false
 parent: SidecarTridge TOS
@@ -23,13 +23,15 @@ You should read this section to ensure that your Atari ST model is compatible wi
 
 ## Supported Atari ST Motherboards and Carrier Boards
 
+The tables below tell you whether your motherboard is supported by the SidecarTridge TOS emulator and how many ROM chips it has. To know which specific SidecarTridge TOS emulator kit you need to order for that motherboard, see the kit table in [Before You Buy](/sidecartridge-tos/before-buy/#purchase-the-right-sidecartridge-tos-emulator-kit).
+
 {: .info}
 Carrier boards for non supported motherboards are in active development. Please check the SidecarTridge website for updates.
 {: .warning}
 
 ### Atari ST series
 
-| Motherboard Model Number | Number of ROMs | Carrier Board   |
+| Motherboard Model Number | Number of ROMs | Status          |
 |--------------------------|----------------|-----------------|
 | C070115 Rev. 2           |                | Not supported   |
 | C070243 Rev. C           |    2 and 6     | Supported       |
@@ -57,7 +59,7 @@ Carrier boards for non supported motherboards are in active development. Please 
 
 ### Atari Mega ST series
 
-| Motherboard Model Number | Number of ROMs | Carrier Board   |
+| Motherboard Model Number | Number of ROMs | Status          |
 |--------------------------|----------------|-----------------|
 | C100167-001 Rev. 4.0     |       2        | Supported       |
 | C100167-001 Rev. B       |       2        | Supported       |
@@ -68,14 +70,14 @@ Carrier boards for non supported motherboards are in active development. Please 
 
 ### Atari STE series
 
-| Motherboard Model Number | Number of ROMs | Carrier Board   |
+| Motherboard Model Number | Number of ROMs | Status          |
 |--------------------------|----------------|-----------------|
 | CA4003290                |       2        | Supported       |
 
 
 ### Atari Mega STE series
 
-| Motherboard Model Number | Number of ROMs | Carrier Board   |
+| Motherboard Model Number | Number of ROMs | Status          |
 |--------------------------|----------------|-----------------|
 | CA400677 Rev. F          |       2        | Supported       |
 
@@ -174,6 +176,6 @@ You can learn about the different TOS versions in these videos:
         allowfullscreen allowtransparency></iframe>
 </figure>
 
-[Previous: User Guide](/sidecartridge-tos/user-guide/){: .btn .mr-4 }
+[Previous: Advanced Settings](/sidecartridge-tos/advanced-settings/){: .btn .mr-4 }
 [Main](/sidecartridge-tos/){: .btn .mr-4 }
 [Next: Troubleshooting](/sidecartridge-tos/troubleshooting/){: .btn }

--- a/sidecartridge-tos/compatibility.md
+++ b/sidecartridge-tos/compatibility.md
@@ -34,11 +34,11 @@ Carrier boards for non supported motherboards are in active development. Please 
 | Motherboard Model Number | Number of ROMs | Status          |
 |--------------------------|----------------|-----------------|
 | C070115 Rev. 2           |                | Not supported   |
-| C070243 Rev. C           |    2 and 6     | Supported       |
-| C070243 Rev. E           |    2 and 6     | Supported       |
-| C070243 Rev. F           |    2 and 6     | Supported       |
-| C070243 Rev. H           |    2 and 6     | Supported       |
-| C070243 Rev. I           |    2 and 6     | Supported       |
+| C070243 Rev. C           |       6        | Supported       |
+| C070243 Rev. E           |       6        | Supported       |
+| C070243 Rev. F           |       6        | Supported       |
+| C070243 Rev. H           |       6        | Supported       |
+| C070243 Rev. I           |       6        | Supported       |
 | C070523-001 Rev. C       |    6           | Supported       |
 | C070523-001 Rev. D       |    6           | Supported       |
 | C070789-001 Rev. A       |    2 and 6     | Supported       |

--- a/sidecartridge-tos/getting-started.md
+++ b/sidecartridge-tos/getting-started.md
@@ -7,8 +7,8 @@ parent: SidecarTridge TOS
 
 ---
 
-{: .warn }
-This is a deprecated version of the Getting Started guide for the SidecarTridge TOS emulator with firmware version 1.0. Upgrade to the latest firmware version and refer to the [latest Getting Started guide](/sidecartridge-tos/getting-startedV2/) for the most up-to-date information.
+{: .warning }
+This page documents the SidecarTridge TOS emulator with firmware **v1.0**, which is deprecated. The information below (including the FAT16 references, file system limits and ROM size handling) does not match the current device behaviour. If you are running current firmware, follow the [latest Getting Started guide](/sidecartridge-tos/getting-startedV2/) instead.
 
 #  Getting Started
 {: .no_toc }

--- a/sidecartridge-tos/introduction.md
+++ b/sidecartridge-tos/introduction.md
@@ -154,7 +154,7 @@ The emulator leverages the PIO capabilities of the Raspberry RP2040 and RP235x m
 
 The Flash memory is a non-volatile memory that stores up to 16MB of data. This memory is used to store the TOS image files, the metadata of the ROM image files and the firmware of the device.
 
-Users can connect the emulator to a computer via USB to manage ROM files. The emulator appears as a FAT16 mass storage device, allowing users to easily copy TOS image files and custom ROMs. This USB interface simplifies the process of updating and switching ROMs without physically interacting with the Atari ST’s internals. The file system has been enhanced to provide information about the status of the emulator and the installed ROMs, as well as the ability to modify the default and rescue ROMs.
+Users can connect the emulator to a computer via USB to manage ROM files. The emulator appears as a FAT12 mass storage device, allowing users to easily copy TOS image files and custom ROMs. This USB interface simplifies the process of updating and switching ROMs without physically interacting with the Atari ST’s internals. The file system has been enhanced to provide information about the status of the emulator and the installed ROMs, as well as the ability to modify the default and rescue ROMs.
 
 ### Hot Swapping the ROMs from the Atari ST
 

--- a/sidecartridge-tos/user-guide.md
+++ b/sidecartridge-tos/user-guide.md
@@ -6,8 +6,8 @@ nav_exclude: true
 parent: SidecarTridge TOS
 ---
 
-{: .warn }
-This is a deprecated version of the User Guide for the SidecarTridge TOS emulator with firmware version 1.0. Upgrade to the latest firmware version and refer to the [latest User Guide](/sidecartridge-tos/user-guideV2/) for the most up-to-date information.
+{: .warning }
+This page documents the SidecarTridge TOS emulator with firmware **v1.0**, which is deprecated. The instructions below may not match the current device behaviour. If you are running current firmware, follow the [latest User Guide](/sidecartridge-tos/user-guideV2/) instead.
 
 # User Guide
 {: .no_toc }


### PR DESCRIPTION
## Summary

Audit pass on the SidecarTridge TOS Emulator docs (analogous to the Kickstart audit in #57 - #60) surfaced several concrete issues that mislead users or contradict the rest of the documentation. This PR fixes the unambiguous ones; structural rewrites and typo polish are left for follow-up PRs.

Skipped from this batch on purpose:
- The two `STF and STFM Kit C070789 C103175 C103414` rows in `before-buy.md` that share a kit name with different Shopify variants and different ROM counts. Confirmed intentional (same kit name, different ROM-count variants), no change needed.

## Changes

- **`compatibility.md`** (`title`): frontmatter `Compatbility` corrected to `Compatibility`. The typo was visible in the HTML `<title>` and the just-the-docs sidebar.
- **`compatibility.md`** (column header): the `Carrier Board` column header was paired with `Supported` / `Not supported` values, which is status, not carrier information. Renamed the column header to `Status` in every per-family table and added a short paragraph above the tables pointing at the kit selector in `before-buy.md` so the reader knows where to find the actual SKU mapping.
- **`compatibility.md`** (Previous button): pointed at the v1.0 (deprecated) User Guide URL even though the current nav order places Advanced Settings immediately before Compatibility. Repointed to `/sidecartridge-tos/advanced-settings/`.
- **`compatibility.md`** (C070243 ROM counts): the five `C070243` rows (Rev. C / E / F / H / I) showed `2 and 6` ROMs even though only the 6-ROM kit variant exists for that motherboard model. The 2 / 6 split is real for the C070789 / C103175 / C103414 family (correctly listed elsewhere) but not for C070243. Updated the five rows to `6`.
- **`introduction.md`** (FAT16): the USB section claimed the device appears as a `FAT16 mass storage device`. V2 docs and the firmware changelog (since 2.0.0) document FAT12 with a 4 KB cluster size. Aligned the introduction with the rest of the documentation.
- **`getting-started.md`** and **`user-guide.md`** (V1, deprecated): the deprecation banner used the unknown just-the-docs callout class `.warn`, so it rendered as a plain paragraph rather than a highlighted warning box. Switched to `.warning` and reworded the text to make it explicit that the V1 page is for firmware v1.0 only and that several of its statements (e.g. FAT16 file system, image size handling) do not match the current device.
- **`changelog.md`** (Hardware Changelog v3.0.0): described the hardware as `SidecarTridge Kickstart v3 board`. In the TOS Emulator docs that should refer to the ROM Emulator v3 board, not Kickstart. Replaced with `SidecarTridge ROM Emulator v3 board`. No other changelog entries were touched.
- **`before-buy.md`** (motherboard prefix): two motherboard references in the kit table were missing the leading `C` prefix (`070523`, `070789-001`). Added the prefix so the column is consistent with the rest of the table and with the compatibility page.

## Test plan

- [ ] Render the six changed pages.
- [ ] Confirm the sidebar shows `Compatibility` (not `Compatbility`).
- [ ] Open both V1 pages and confirm the deprecation banner now renders as a highlighted warning callout.
- [ ] Click the Previous button on Compatibility and confirm it lands on Advanced Settings.
- [ ] In the Compatibility table, confirm all five C070243 rows show `6` (not `2 and 6`).
- [ ] Grep the TOS docs for `Carrier Board   |` and `Kickstart v3 board` to confirm both are gone.