### PR TITLE
docs(multidevice): fix V1 deprecation banners, broken nav links, typos

### DIFF
--- a/sidecartridge-multidevice/compatibility_issues.md
+++ b/sidecartridge-multidevice/compatibility_issues.md
@@ -11,6 +11,9 @@ redirect_from:
 
 # Compatibility Issues
 
+{: .warning }
+This page documents the SidecarTridge Multi-device with **firmware v1.0**, which is deprecated. The compatibility statements below (notably the claim that Atari TT and Falcon are not supported) do not match the current device behaviour. If you are running current firmware, follow the [latest Compatibility page](/sidecartridge-multidevice/compatibility_v2/) instead.
+
 ## Warning to all users
 SidecarTridge Multi-device has undergone extensive testing on various Atari ST, STE, MegaST, and MegaSTE computers featuring diverse TOS versions. However, it's important to note that this version does not support Atari TT, Falcon computers, and their clones. While heavily modified and customized computers are likely compatible, it’s up to you to decide to use the Multi-device.
 

--- a/sidecartridge-multidevice/faq.md
+++ b/sidecartridge-multidevice/faq.md
@@ -10,6 +10,10 @@ redirect_from:
 ---
 
 # Frequently Asked Questions
+
+{: .warning }
+This page documents the SidecarTridge Multi-device with **firmware v1.0**, which is deprecated. Some answers below no longer apply to the current device. If you are running current firmware, follow the [latest FAQ](/sidecartridge-multidevice/faq_v2/) instead.
+
 This section compiles a list of frequently asked questions (FAQs) about the SidecarTridge Multi-device board, aimed at addressing common inquiries, clarifications, and concerns. Developers are encouraged to consult this section for quick references and insights.
 
 ## General Questions

--- a/sidecartridge-multidevice/faq_v2.md
+++ b/sidecartridge-multidevice/faq_v2.md
@@ -2,7 +2,7 @@
 layout: default
 title: Frequently Asked Questions V2.0
 nav_order: 9
-nav_exclude: true
+nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:
   - /faq_v2

--- a/sidecartridge-multidevice/getting_started.md
+++ b/sidecartridge-multidevice/getting_started.md
@@ -12,6 +12,9 @@ redirect_from:
 # Getting Started
 {: .no_toc }
 
+{: .warning }
+This page documents the SidecarTridge Multi-device with **firmware v1.0**, which is deprecated. Some statements below (microSD format, supported Atari models, etc.) do not match the current device behaviour. If you are running current firmware, follow the [latest Getting Started guide](/sidecartridge-multidevice/getting_started_v2/) instead.
+
 This section provides guidance on the initial steps to start working with the SidecarTridge Multi-device board. If you are a developer or maker it includes prerequisites, board assembly instructions, setup and configuration. Developers and Makers can also ensure a smooth start to their journey with the Multi-device board by following the procedures outlined in this and coming sections.
 
 <details open markdown="block">

--- a/sidecartridge-multidevice/how_to.md
+++ b/sidecartridge-multidevice/how_to.md
@@ -12,7 +12,10 @@ redirect_from:
 # How to
 {: .no_toc }
 
-This section showcases a variety of different configurations and parametric setups for the SidecarTridge Multi-device board. You don't need to be a developer to follow these guides, but you will need to be familiar with the basics of the Atari ST and the Multi-device board. If you are new to the Multi-device project, please refer to the [Getting Started](/sidecartridge-multidevice/getting_started/) section first.
+{: .warning }
+This page documents the SidecarTridge Multi-device with **firmware v1.0**, which is deprecated. Several recipes below (microSD format, ROM/floppy folder layout, configuration tool) do not match the current device behaviour. If you are running current firmware, follow the [latest How to guide](/sidecartridge-multidevice/how_to_v2/) instead.
+
+This section showcases a variety of different configurations and parametric setups for the SidecarTridge Multi-device board. You don't need to be a developer to follow these guides, but you will need to be familiar with the basics of the Atari ST and the Multi-device board. If you are new to the Multi-device project, please refer to the [Getting Started (v2)](/sidecartridge-multidevice/getting_started_v2/) section first.
 
 <details open markdown="block">
   <summary>

--- a/sidecartridge-multidevice/index.md
+++ b/sidecartridge-multidevice/index.md
@@ -153,7 +153,7 @@ You can learn about the new features and improvements in the latest firmware rel
 
   <div class="toc-card">
     <span class="toc-chip chip-ref">Reference</span>
-    <h3>🤝 <a href="/sidecartridge-multidevice/compatibility_issues/">Compatibility</a></h3>
+    <h3>🤝 <a href="/sidecartridge-multidevice/compatibility_v2/">Compatibility</a></h3>
     <p>Please read this section if you have issues with your SidecarTridge Multi-device.</p>
   </div>
 
@@ -195,7 +195,7 @@ You can learn about the new features and improvements in the latest firmware rel
 
   <div class="toc-card">
     <span class="toc-chip chip-ref">Reference</span>
-    <h3>🗄️ <a href="/sidecartridge-multidevice/unofficial_firmwares/">Unoficial Firmwares</a></h3>
+    <h3>🗄️ <a href="/sidecartridge-multidevice/unofficial_firmwares/">Unofficial Firmwares</a></h3>
     <p>Smart people out there building incredible stuff with the device</p>
   </div>
 

--- a/sidecartridge-multidevice/parameters.md
+++ b/sidecartridge-multidevice/parameters.md
@@ -11,8 +11,11 @@ redirect_from:
 
 # Configuration Parameters
 
-{: warning}
-Please modify the parameters with caution, as they can affect the behavior of the SidecarTridge Multi-device board. Read the [User Guide](/sidecartridge-multidevice/userguide/) section for more information.
+{: .warning }
+This page documents the SidecarTridge Multi-device parameter set for **firmware v1.0**, which is deprecated. Several parameters listed below have been removed or replaced in current firmware. If you are running current firmware, see the [latest Parameters page](/sidecartridge-multidevice/parameters_v2/) instead.
+
+{: .warning }
+Please modify the parameters with caution, as they can affect the behavior of the SidecarTridge Multi-device board. Read the [User Guide (v1.0)](/sidecartridge-multidevice/userguide/) section for more information.
 
 | Parameter            | Type      | Description                                            | Released | Default                              |
 |:---------------------|:----------|:-------------------------------------------------------|:---------|:-------------------------------------|
@@ -59,7 +62,7 @@ Please modify the parameters with caution, as they can affect the behavior of th
 | WIFI_IP              | STRING    | The IP address of the WiFi network when DHCP disabled  | v1.0.0   |                                      |
 | WIFI_NETMASK         | STRING    | The netmask of the WiFi network when DHCP disabled     | v1.0.0   |                                      |
 | WIFI_PASSWORD        | STRING    | The password of the WiFi network to connect to         | v0.0.1   |                                      |
-| WIFI_POWER           | INTEGER   | The power configuration of the Wifi chip. 0 - power management disabled 1 - Maximize performance 2 - Aggresive power management 3 - Default chip values 4 - No power saving               | v1.0.0   | 0
+| WIFI_POWER           | INTEGER   | The power configuration of the Wifi chip. 0 - power management disabled 1 - Maximize performance 2 - Aggresive power management 3 - Default chip values 4 - No power saving               | v1.0.0   | 0                                    |
 | WIFI_RSSI            | BOOLEAN   | Show RSSI of the connected network:                    | v1.0.0   | true                                 |
 | WIFI_SCAN_SECONDS    | INTEGER   | The number of seconds to scan for WiFi networks        | v0.0.1   | 15                                   |
 | WIFI_SSID            | STRING    | The SSID of the WiFi network to connect to             | v0.0.1   |                                      |

--- a/sidecartridge-multidevice/parameters_v2.md
+++ b/sidecartridge-multidevice/parameters_v2.md
@@ -11,7 +11,7 @@ redirect_from:
 
 # Configuration Parameters for Firmware v2
 
-{: warning}
+{: .warning }
 Please modify the parameters with caution, as they can affect the behavior of the SidecarTridge Multi-device board. Read the [User Guide](/sidecartridge-multidevice/userguide_v2/) section for more information.
 
 The number of parameters have been reduced in this version. The parameters that were removed are now set automatically based on the detected hardware and configuration.

--- a/sidecartridge-multidevice/revisions.md
+++ b/sidecartridge-multidevice/revisions.md
@@ -10,7 +10,6 @@ redirect_from:
 
 # Board revisions
 {: .no_toc }
-{: .no_toc }
 
 <details open markdown="block">
   <summary>

--- a/sidecartridge-multidevice/troubleshooting.md
+++ b/sidecartridge-multidevice/troubleshooting.md
@@ -11,6 +11,9 @@ redirect_from:
 # Troubleshooting
 {: .no_toc }
 
+{: .warning }
+This page documents the SidecarTridge Multi-device with **firmware v1.0**, which is deprecated. Some symptoms and fixes below no longer apply to the current device. If you are running current firmware, follow the [latest Troubleshooting guide](/sidecartridge-multidevice/troubleshooting_v2/) instead.
+
 This section is dedicated to assisting developers in resolving issues encountered while working with the SidecarTridge Multi-device board. It includes common troubleshooting steps, frequently asked questions, and resources for additional support, enabling developers to find solutions and get back to development swiftly.
 
 <details open markdown="block">

--- a/sidecartridge-multidevice/unofficial_firmwares.md
+++ b/sidecartridge-multidevice/unofficial_firmwares.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Unoficial Firmwares
+title: Unofficial Firmwares
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:
@@ -8,7 +8,7 @@ redirect_from:
   - /unoficial_firmwares/
 ---
 
-# Unoficial Firmwares
+# Unofficial Firmwares
 {: .no_toc }
 
 <details open markdown="block">
@@ -20,7 +20,7 @@ redirect_from:
 {:toc}
 </details>
 
-## List of Unoficial firmwares available
+## List of Unofficial firmwares available
 
 
 |  |  |

--- a/sidecartridge-multidevice/userguide.md
+++ b/sidecartridge-multidevice/userguide.md
@@ -12,6 +12,9 @@ redirect_from:
 # User Guide
 {: .no_toc }
 
+{: .warning }
+This page documents the SidecarTridge Multi-device with **firmware v1.0**, which is deprecated. Several statements below (microSD format, advanced settings, Booster app workflow, etc.) do not match the current device behaviour. If you are running current firmware, follow the [latest User Guide](/sidecartridge-multidevice/userguide_v2/) instead.
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/sidecartridge-multidevice/userguide_v2.md
+++ b/sidecartridge-multidevice/userguide_v2.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: User Guide Firmware V2.0 
+title: User Guide Firmware V2.0
 nav_order: 3
-nav_exclude: true
+nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:
   - /userguide_v2/


### PR DESCRIPTION
## Summary

P0 batch from the Multi-device docs audit (companion to #57 - #63 for Kickstart and TOS). Fixes the unambiguous bugs; structural cleanup (nav_order normalisation, V1 forward cross-links, typos in long-form text) is queued for follow-up PRs.

## Changes

- **`index.md`**: the `Compatibility` ToC card linked to the deprecated V1 page `compatibility_issues/`. Repointed to `compatibility_v2/`.
- **`index.md`** and **`unofficial_firmwares.md`**: typo `Unoficial` to `Unofficial` in four visible places (index card text + frontmatter title + H1 + H2 in the page). The file name and the `redirect_from: /unoficial_firmwares/` alias are intentionally untouched so old links keep working.
- **`userguide_v2.md`** and **`faq_v2.md`**: both had `nav_exclude: true`, so the V2 user guide and V2 FAQ were absent from the sidebar even though they are the canonical pages linked from the main grid. Set to `nav_exclude: false`.
- **V1 firmware pages**: deprecation banners added to all seven V1 pages (`getting_started`, `userguide`, `how_to`, `troubleshooting`, `compatibility_issues`, `faq`, `parameters`). Each banner uses the just-the-docs `.warning` callout so it renders as a yellow warning box and points the reader at the corresponding V2 page. Without these banners, users reaching a V1 page via search or an old bookmark were reading stale info (FAT16 microSD, no-TT-or-Falcon, etc.) as if it were current.
- **`parameters.md`** (V1): the `WIFI_POWER` row was missing the trailing pipe `|`, which broke markdown table rendering after that row. Added the missing pipe.
- **`parameters.md`** (V1) and **`parameters_v2.md`**: the in-page warning callout used `{: warning}` instead of `{: .warning }` (missing dot, missing space). just-the-docs only styles the callout when the class is `.warning`. Corrected both.
- **`revisions.md`**: duplicate `{: .no_toc }` marker on consecutive lines collapsed to a single occurrence.

## Test plan

- [ ] Render the changed pages.
- [ ] Confirm the main index grid `Compatibility` card opens the V2 page.
- [ ] Confirm the sidebar now shows `User Guide Firmware V2.0` and `Frequently Asked Questions V2.0`.
- [ ] Open each V1 page and confirm the new yellow warning callout is visible at the top.
- [ ] On `parameters.md`, confirm the WIFI_POWER row no longer breaks the table.
- [ ] Grep the multidevice docs for `Unoficial` and confirm only the `redirect_from` aliases remain.