### PR TITLE
docs(multidevice): normalise nav_order and document v2 stubs

### DIFF
--- a/sidecartridge-multidevice/cases.md
+++ b/sidecartridge-multidevice/cases.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Enclosures/Cases
+nav_order: 13
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:

--- a/sidecartridge-multidevice/compatibility_v2.md
+++ b/sidecartridge-multidevice/compatibility_v2.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Compatibility Issues V2.0
-nav_order: 8
+nav_order: 10
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:

--- a/sidecartridge-multidevice/faq_v2.md
+++ b/sidecartridge-multidevice/faq_v2.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Frequently Asked Questions V2.0
-nav_order: 9
+nav_order: 12
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:
@@ -11,6 +11,9 @@ redirect_from:
 
 # Frequently Asked Questions
 This section compiles a list of frequently asked questions (FAQs) about the SidecarTridge Multi-device board, aimed at addressing common inquiries, clarifications, and concerns. Developers are encouraged to consult this section for quick references and insights.
+
+{: .note }
+This page is being migrated from the [v1.0 FAQ](/sidecartridge-multidevice/faq/). New answers will be added here as they are validated against the current firmware. In the meantime, the v1.0 FAQ is the closest available source, but its answers may no longer reflect current behaviour.
 
 ## General Questions
 

--- a/sidecartridge-multidevice/parameters_v2.md
+++ b/sidecartridge-multidevice/parameters_v2.md
@@ -11,6 +11,9 @@ redirect_from:
 
 # Configuration Parameters for Firmware v2
 
+{: .note }
+This page is being migrated from the [v1.0 Parameters reference](/sidecartridge-multidevice/parameters/). The current firmware exposes a reduced parameter set (most knobs are now set automatically based on the detected hardware and configuration) and the full reference table will be republished here once the firmware-side documentation is finalised. In the meantime, the v1.0 page is the closest available reference for the parameter names that still exist.
+
 {: .warning }
 Please modify the parameters with caution, as they can affect the behavior of the SidecarTridge Multi-device board. Read the [User Guide](/sidecartridge-multidevice/userguide_v2/) section for more information.
 

--- a/sidecartridge-multidevice/publicfloppydb.md
+++ b/sidecartridge-multidevice/publicfloppydb.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Public Floppy DB
+nav_order: 15
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:

--- a/sidecartridge-multidevice/publicromdb.md
+++ b/sidecartridge-multidevice/publicromdb.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Public ROM DB
+nav_order: 16
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:

--- a/sidecartridge-multidevice/revisions.md
+++ b/sidecartridge-multidevice/revisions.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Board revisions
+nav_order: 14
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:

--- a/sidecartridge-multidevice/troubleshooting_v2.md
+++ b/sidecartridge-multidevice/troubleshooting_v2.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Troubleshooting V2.0
+nav_order: 11
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:

--- a/sidecartridge-multidevice/unofficial_firmwares.md
+++ b/sidecartridge-multidevice/unofficial_firmwares.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Unofficial Firmwares
+nav_order: 17
 nav_exclude: false
 parent: SidecarTridge Multi-device
 redirect_from:


### PR DESCRIPTION
## Summary

P1 structural follow-up to #64.

## Changes

- `nav_order` is now assigned to every visible (non `nav_excluded`) V2 page in the order shown by the main index grid, with no collisions and no missing values:

  | order | page |
  |---|---|
  | 1 | `introduction` |
  | 2 | `getting_started_v2` |
  | 3 | `userguide_v2` |
  | 4 | `architecture_and_design` |
  | 5 | `hardware_interface` |
  | 7 | `programming` |
  | 8 | `parameters_v2` |
  | 9 | `how_to_v2` |
  | 10 | `compatibility_v2` (was 8) |
  | 11 | `troubleshooting_v2` (was missing) |
  | 12 | `faq_v2` (was 9) |
  | 13 | `cases` (was missing) |
  | 14 | `revisions` (was missing) |
  | 15 | `publicfloppydb` (was missing) |
  | 16 | `publicromdb` (was missing) |
  | 17 | `unofficial_firmwares` (was missing) |

  V1 deprecated and other `nav_excluded` pages keep their existing `nav_order` since they do not affect the sidebar.

- `parameters_v2.md` and `faq_v2.md` are intentionally kept (per product decision) but were essentially empty. Added a `Content being migrated from the v1.0 version` note callout to each so readers landing on these stubs understand they are placeholders rather than 404s and know where to find the current closest reference.

## Test plan

- [ ] Render the sidebar and confirm the order matches the index grid.
- [ ] Confirm `parameters_v2.md` and `faq_v2.md` now show a blue `.note` callout at the top.