### PR TITLE
docs(multidevice): typo pass

### DIFF
--- a/sidecartridge-multidevice/getting_started.md
+++ b/sidecartridge-multidevice/getting_started.md
@@ -107,7 +107,7 @@ To begin with the Multi-device board, **developers are required to have a minimu
 
 - **Integration with GDB**: Skills in using GDB for debugging software, setting breakpoints, inspecting variables, and analyzing program flow, especially in conjunction with Visual Studio Code, are essential for troubleshooting and ensuring software stability.
 
-And if you want to contribute to the harware, skills in reading schematics, understanding electronic components, and practical skills like soldering will facilitate working with the hardware aspects of Multi-device.
+And if you want to contribute to the hardware, skills in reading schematics, understanding electronic components, and practical skills like soldering will facilitate working with the hardware aspects of Multi-device.
     
 {: .note }
 Even if you’re not an expert in all these areas, your contribution is still valuable. Engage, learn, and grow with the Multi-device community!

--- a/sidecartridge-multidevice/getting_started_v2.md
+++ b/sidecartridge-multidevice/getting_started_v2.md
@@ -280,7 +280,7 @@ To begin with the Multi-device board, **developers are required to have a minimu
 
 - **Integration with GDB**: Skills in using GDB for debugging software, setting breakpoints, inspecting variables, and analyzing program flow, especially in conjunction with Visual Studio Code, are essential for troubleshooting and ensuring software stability.
 
-And if you want to contribute to the harware, skills in reading schematics, understanding electronic components, and practical skills like soldering will facilitate working with the hardware aspects of Multi-device.
+And if you want to contribute to the hardware, skills in reading schematics, understanding electronic components, and practical skills like soldering will facilitate working with the hardware aspects of Multi-device.
     
 {: .note }
 Even if you’re not an expert in all these areas, your contribution is still valuable. Engage, learn, and grow with the Multi-device community!

--- a/sidecartridge-multidevice/troubleshooting.md
+++ b/sidecartridge-multidevice/troubleshooting.md
@@ -76,7 +76,7 @@ The cartridge drive uses the letter `c` in lowercase. If you can't see the `Driv
    - Click on any other unit (e.g. `FLOPPY DISK` or `HARD DISK`).
    - Open the `Options` menu at the top of the screen.
    - Click on `Install Disk Drive...`.
-   - Change `Drive identifier` to `c` **in lower casee**.
+   - Change `Drive identifier` to `c` **in lowercase**.
    - You should also rename `Icon label` to `Cartridge` or `Cartridge Drive` to make it easier to identify.
    - Finally, click on `Install`. The `Drive c:` unit should now be visible. Open it and click twice on the application `SIDECART.TOS` to run it.
 

--- a/sidecartridge-multidevice/userguide.md
+++ b/sidecartridge-multidevice/userguide.md
@@ -351,7 +351,7 @@ This section explains how to select the floppy image to emulate from the databas
 ### Set the URL of the database and images files
 
 {: .warning }
-For avanced users only.
+For advanced users only.
 
 The Multi-device can be configured to use a web server to host both the database and images files. It's not necessary to have both in the same server. 
 


### PR DESCRIPTION
## Summary

Final follow-up to #64 and #65. Pure typo polish, no semantic changes.

## Changes

- `getting_started.md` and `getting_started_v2.md`: `contribute to the harware` to `contribute to the hardware`.
- `troubleshooting.md`: `Change Drive identifier to c in lower casee` to `in lowercase`.
- `userguide.md`: `For avanced users only` to `For advanced users only`.

## Test plan

- [ ] Render the four changed pages and confirm the wording reads cleanly.