### PR TITLE
docs(keyboard): seed FAQ with the two questions most likely to come up before purchase

### DIFF
--- a/sidecartridge-keyboard/faq.md
+++ b/sidecartridge-keyboard/faq.md
@@ -22,7 +22,17 @@ This page is reserved for frequently asked questions about the SidecarTridge Key
 
 ## Purpose
 
-As the project documentation grows, this page can collect the short answers that do not need a full chapter.
+As the project documentation grows, this page collects the short answers that do not need a full chapter.
+
+## Hardware compatibility
+
+### Why is there no Croissant version for Atari ST computers with an external PSU ("short ST")?
+
+The Croissant version of the SidecarTridge Keyboard Emulator is built for the 7-pin keyboard connector. The "short ST" motherboards (C070115 and C070243) use an 18-pin keyboard connector instead and are easy to recognise because they ship with an external power supply. Supporting them would require a different adapter design, which is not on the short-term roadmap. See [Troubleshooting → Why is there no Croissant version for Atari ST computers with an external PSU](/sidecartridge-keyboard/troubleshooting/#why-is-there-no-croissant-version-for-atari-st-computers-with-an-external-psu-short-st) for more detail.
+
+### What is the difference between Croissant and Soufflè?
+
+Croissant is the internal variant: it installs inside the Atari ST keyboard area, between the motherboard and the original keyboard, so the original case stays closed. Soufflè is the external dongle variant, designed for Atari Mega ST and Mega STe systems, and plugs into the coiled keyboard cable. Both variants share the same firmware base. See the [Introduction](/sidecartridge-keyboard/introduction/) for the full feature breakdown.
 
 [Previous: Troubleshooting](/sidecartridge-keyboard/troubleshooting/){: .btn .mr-4 }
 [Main](/sidecartridge-keyboard/){: .btn .mr-4 }


### PR DESCRIPTION
## Summary

Follow-up to #67. The keyboard FAQ page was an explicit placeholder (`This page is reserved...`). The product is already on sale, so the placeholder state risks looking abandoned to buyers who land on the FAQ from the sidebar or the main grid. Seeded the page with two FAQs that come up most often before purchase.

## Changes

- Added FAQ entry **"Why is there no Croissant version for Atari ST computers with an external PSU (short ST)?"**. The same answer currently lives in `troubleshooting.md`; the FAQ now gives a short answer and cross-links the longer one.
- Added FAQ entry **"What is the difference between Croissant and Soufflè?"**. Helps buyers pick the right variant without first reading the full Introduction page.
- Updated the "Purpose" paragraph wording from `this page can collect` to `this page collects` to match the new non-placeholder state.

## Test plan

- [ ] Render `faq.md` and confirm the new entries appear under a `Hardware compatibility` section.
- [ ] Click through the cross-link to the troubleshooting entry and confirm the anchor lands correctly.