### PR TITLE
docs(tos256): fix mislabeled column, asset typo and intro grammar

### DIFF
--- a/sidecartridge-tos-256kb-decoder/before-buy.md
+++ b/sidecartridge-tos-256kb-decoder/before-buy.md
@@ -36,7 +36,7 @@ Most of the Mega ST motherboards have a Blitter patch soldered on top of the Mot
 
 ### Purchase the Right SidecarTridge TOS 256KB Decoder Kit
 
-Once you have verified the compatibility of your Atari Mega ST motherboard and that you are using the SidecarTridge TOS Emulator carrier board revision 4 or higher, you can proceed to purchase the appropriate SidecarTridge TOS 256KB Decoder emulator kit. Ensure you select the correct kit based on your motherboard model number.
+Once you have verified the compatibility of your Atari Mega ST motherboard and that you are using the SidecarTridge TOS Emulator carrier board revision 4 or higher, you can proceed to purchase the appropriate SidecarTridge TOS 256KB Decoder kit. Ensure you select the correct kit based on your motherboard model number.
 
 
 | Kit | Supported Motherboards |

--- a/sidecartridge-tos-256kb-decoder/compatibility.md
+++ b/sidecartridge-tos-256kb-decoder/compatibility.md
@@ -29,7 +29,7 @@ Carrier boards for unsupported motherboards are in active development. Please ch
 {: .warning}
 Older SidecarTridge TOS Emulator carrier board revisions are not covered by the current installation process. See the [discontinued hardware installation page](/sidecartridge-tos-256kb-decoder/hardware-installation-discontinued/) for reference only.
 
-| Motherboard Model Number | Number of ROMs | Carrier Board   |
+| Motherboard Model Number | Number of ROMs | Status          |
 |--------------------------|----------------|-----------------|
 | C100167-001 Rev. 4.0     |       2        | Supported       |
 | C100167-001 Rev. B       |       2        | Supported       |

--- a/sidecartridge-tos-256kb-decoder/hardware-installation.md
+++ b/sidecartridge-tos-256kb-decoder/hardware-installation.md
@@ -59,7 +59,7 @@ The following images show the current Mega ST decoder board on its own, making i
 
 ![SidecarTridge TOS 256KB Decoder board top view for Mega ST](/sidecartridge-tos-256kb-decoder/assets/images/256KB-DECODER-BOARD-MEGABUS-TOP.png)
 
-![SidecarTridge TOS 256KB Decoder board perspective view for Mega ST](/sidecartridge-tos-256kb-decoder/assets/images/256KB-DECODER-BOARD-MEGABUS-PERSPCTIVE.png)
+![SidecarTridge TOS 256KB Decoder board perspective view for Mega ST](/sidecartridge-tos-256kb-decoder/assets/images/256KB-DECODER-BOARD-MEGABUS-PERSPECTIVE.png)
 
 Before pressing the board into place, double-check that the connector is aligned correctly and that the cable will not be twisted or pinched once installed.
 

--- a/sidecartridge-tos-256kb-decoder/introduction.md
+++ b/sidecartridge-tos-256kb-decoder/introduction.md
@@ -48,7 +48,7 @@ The 256KB TOS versions 1.06, 1.62, and 2.05 are not compatible with Atari ST and
 
 ## Intended Audience
 
-The SidecarTridge TOS emulator and the 256KB Decoder are designed for ANY Mega ST enthusiasts, hobbyists, and developers who wish to explore and experiment with different TOS versions and custom ROMs. It's suitable any user, even without a basic understanding of electronics and soldering skills, as the add-on board is plugged into the MEGABUS connector of the Atari Mega ST computer.
+The SidecarTridge TOS emulator and the 256KB Decoder are designed for any Mega ST enthusiasts, hobbyists, and developers who wish to explore and experiment with different TOS versions and custom ROMs. It is suitable for any user, even without a basic understanding of electronics and soldering skills, since the add-on board plugs into the MEGABUS connector of the Atari Mega ST computer.
 
 ## Project Background
 


### PR DESCRIPTION
## Summary

Audit pass on the SidecarTridge TOS 256KB Decoder docs (6 pages, 593 lines). The product documentation is small and overall in good shape; this PR collects the four concrete issues found.

## Changes

- **`compatibility.md`**: the per-family table header was `Carrier Board` but the values were `Supported` / `Not supported`, i.e. status, not carrier. Renamed the header to `Status` (same fix applied to `sidecartridge-tos` in #61).
- **Asset rename**: `256KB-DECODER-BOARD-MEGABUS-PERSPCTIVE.png` to `256KB-DECODER-BOARD-MEGABUS-PERSPECTIVE.png`. Updated the single reference in `hardware-installation.md` line 62.
- **`introduction.md`** (Intended Audience): `It's suitable any user, even without...` was missing the preposition `for`. Reworded the sentence to `It is suitable for any user, even without...` and tightened the surrounding clause.
- **`before-buy.md`** (Step 4 paragraph): `the appropriate SidecarTridge TOS 256KB Decoder emulator kit` - the trailing `emulator` was a copy-paste from the TOS Emulator wording. Removed so the product is referred to by its actual name.

## Test plan

- [ ] Render `compatibility.md` and confirm the column header now reads `Status`.
- [ ] Render `hardware-installation.md` and confirm the perspective image still loads.
- [ ] Render `introduction.md` and confirm the Intended Audience paragraph reads cleanly.