### PR TITLE
docs(acsi2stm): fix tangled prev/next nav, slot label typo and copy issues

### DIFF
--- a/acsi2stm-atari-st/faq.md
+++ b/acsi2stm-atari-st/faq.md
@@ -38,7 +38,7 @@ Only the leftmost slot labeled SD0 (C: / L:) is available for ACSI mode.
 
 These TOS versions can execute the embedded GEMDRIVE driver. These driver can change the order of the GEMDRIVE and ACSI units. As a rule of thumb, ACSI should be used in the slot labeled SD0 (C: / L:), and SD1 and SD2 can be used by GEMDRIVE.
 
-### Why can't see GEMDRIVE units in EmuTOS and TOS 2.0x?
+### Why can't I see GEMDRIVE units in EmuTOS and TOS 2.0x?
 
 To use GEMDRIVE units under EmuTOS and TOS 2.0x you must ensure that the **GEMDRIVE.PRG** driver is executed at boot time. This driver is included firmware package of the project in the **tools** folder of the [release package](https://github.com/retro16/acsi2stm/releases/tag/5.00).
 
@@ -64,6 +64,6 @@ Both drink from the sources of the Hatari emulator. The GEMDRIVE in the ACSI2STM
 
 
 
-[Previous: Internal riser boards](/acsi2stm-atari-st/riser-boards/){: .btn .mr-4 }
+[Previous: Troubleshooting](/acsi2stm-atari-st/troubleshooting/){: .btn .mr-4 }
 [Main](/acsi2stm-atari-st/){: .btn .mr-4 }
-[Next: FAQ](/acsi2stm-atari-st/faq/){: .btn }
+[Next: Enclosures/Cases](/acsi2stm-atari-st/cases/){: .btn }

--- a/acsi2stm-atari-st/introduction.md
+++ b/acsi2stm-atari-st/introduction.md
@@ -37,7 +37,7 @@ The ACSI2STM project was initiated to provide a modern storage solution for Atar
 The project is released under the [GNU General Public License v3.0](https://github.com/retro16/acsi2stm/blob/stable/LICENSE), ensuring that the source code and schematics are freely available for anyone to use, modify, and distribute.
 
 The ACSI2STM device manufactured by SidecarTridge is a derivative of the original project with the following modifications:
-- The size of the PCB has been reduced some milimiters to avoid cabling issues in the Atari Mega ST model.
+- The size of the PCB has been reduced by a few millimetres to avoid cabling issues in the Atari Mega ST model.
 - The 32Mhz crystal has been added to the PCB to improve the stability of the device (I don't know the reason why it was not included in the original project).
 - The jumpers settings have been left in the PCB to allow the user to change the configuration without the need of soldering.
 

--- a/acsi2stm-atari-st/riser-boards.md
+++ b/acsi2stm-atari-st/riser-boards.md
@@ -139,5 +139,4 @@ If the installation does not work as expected, check the following first:
 Before closing the case completely, it is a good idea to perform a partial test boot and confirm that the board sits flat, powers correctly, has no pinched cables, and that the Atari detects the storage device normally.
 
 [Previous: Enclosures/Cases](/acsi2stm-atari-st/cases/){: .btn .mr-4 }
-[Main](/acsi2stm-atari-st/){: .btn .mr-4 }
-[Next: FAQ](/acsi2stm-atari-st/faq/){: .btn }
+[Main](/acsi2stm-atari-st/){: .btn }

--- a/acsi2stm-atari-st/user-guide.md
+++ b/acsi2stm-atari-st/user-guide.md
@@ -51,7 +51,7 @@ The ACSI2STM version of SidecarTridge does have placeholders for the IDC20 conne
 If you want to use the legacy ACSI mode with, for example with some already built images, you can follow these steps:
 
 1. Check that you are running a compatible TOS version with the drivers installed in your disk image. Usually everything above TOS 1.04 is safe.
-2. Insert the microSD with the image burned in the leftmost slot labeled as SDO0 (C: / L:)
+2. Insert the microSD with the image burned in the leftmost slot labeled as SD0 (C: / L:)
 
 ### For GEMDRIVE images only
 
@@ -64,7 +64,7 @@ If you want to use the new GEMDRIVE mode:
 
 If you want to have legacy ACSI mode and the new GEMDRIVE mode available simultaneously, you can configure your system accordingly by following the instructions for both modes:
 
-1. Reserve the leftmost slot labeled as SDO0 (C: / L:) for the legacy ACSI mode image.
+1. Reserve the leftmost slot labeled as SD0 (C: / L:) for the legacy ACSI mode image.
 2. Use the remaining slots for GEMDRIVE mode images.
 3. Follow the compatibility instructions for each mode as described above. Don't forget the GEMDRIVE driver when needed.
 
@@ -114,7 +114,7 @@ All these drivers operate on the same basic principle:
 The formatting and partitioning tool works much like modern equivalents: format the drive, define partitions, apply the settings, and reboot to finalize. 
 
 {: .warning}
-Formatting the a modern SD card with a tool designed 30 years ago can be a daunting task. It is recommended to use a preconfigured image to avoid frustation and time consuming tasks.
+Formatting a modern SD card with a tool designed 30 years ago can be a daunting task. It is recommended to use a preconfigured image to avoid frustration and time consuming tasks.
 
 {: .note}
 If you do want to build your own image without the rabbit hole of legacy tools, [`atari-hd`](https://github.com/sidecartridge/atari-hd) is a multiplatform CLI/TUI (macOS, Linux, Windows) that produces a ready-to-use `.img` in one command. It walks you through size, partition layout (AHDI, PPDRIVER or HDDRIVER) and bootable mode in plain language, and the byte-level output is validated against real ICDFMT- and PPTOSDOS-formatted reference disks.


### PR DESCRIPTION
## Summary

Audit pass on the ACSI2STM Atari ST distribution docs (9 pages, 915 lines). The `nav_order` layout is clean, but the manual Previous/Next buttons at the bottom of several pages were threading the reader through a different sequence than the sidebar. This PR aligns them and fixes the copy-level issues found.

## Navigation fixes

The intended sequence in `nav_order` is `troubleshooting (5) -> faq (6) -> cases (7) -> riser-boards (8, final)`. The buttons were not matching:

- `faq.md`: Previous pointed at `Internal riser boards`, and Next pointed at `FAQ` itself (infinite self-loop). Now Previous = `Troubleshooting`, Next = `Enclosures/Cases`.
- `riser-boards.md`: trailing `Next: FAQ` was sending the reader back into the middle of the chapter. Dropped the Next button; only Previous and Main remain (riser-boards is the last page).

## Content fixes

- `user-guide.md`: the leftmost ACSI slot was labelled `SDO0` (capital O) in two places. The rest of the docs and the device use `SD0` (zero). Normalised both occurrences.
- `user-guide.md`: `Formatting the a modern SD card ... avoid frustation` to `Formatting a modern SD card ... avoid frustration`.
- `faq.md`: question heading `Why can't see GEMDRIVE units...` to `Why can't I see GEMDRIVE units...`.
- `introduction.md`: `reduced some milimiters` to `reduced by a few millimetres`.

## Out of scope

- `before-buy.md` and `cases.md` use H3-only structure where the other products in this repo use H2 Step sections; not fixing in this PR.
- `troubleshooting.md` only has two entries; deliberately kept as is.

## Test plan

- [ ] Walk through the prev/next chain from `introduction` to `riser-boards` and confirm the loop is gone.
- [ ] Render `user-guide.md` and `faq.md` and confirm `SD0` appears consistently.