### PR TITLE
docs: fix broken 256KB Decoder thumbnail on the docs landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -123,7 +123,7 @@ has_toc: false
 
   <div class="proj-card">
     <div class="proj-inner">
-      <img class="proj-thumb" src="/sidecartridge-tos-256kb-decoder/assets/images/256KB-DECODER-BOARD-MEGABUS-PERSPCTIVE.png" alt="SidecarTridge 256KB Decoder for Mega ST thumbnail">
+      <img class="proj-thumb" src="/sidecartridge-tos-256kb-decoder/assets/images/256KB-DECODER-BOARD-MEGABUS-PERSPECTIVE.png" alt="SidecarTridge 256KB Decoder for Mega ST thumbnail">
       <div>
         <h2><a href="/sidecartridge-tos-256kb-decoder/">SidecarTridge TOS 256KB Decoder for Atari Mega ST</a></h2>
         <p>A decoder board that enables 256KB ROM decoding on supported Atari Mega ST systems with the SidecarTridge TOS emulator.</p>


### PR DESCRIPTION
## Summary

The thumbnail for the **SidecarTridge TOS 256KB Decoder** card on the docs landing page (`index.md`) was pointing at the old typo filename `256KB-DECODER-BOARD-MEGABUS-PERSPCTIVE.png` which was renamed to `PERSPECTIVE` (correct spelling) in #69. The reference in `index.md` was missed in that rename, so the thumbnail rendered as a broken image on the live site.

## Fix

One-line `src=` update on `index.md` line 126: `PERSPCTIVE` to `PERSPECTIVE`.

## Repo-wide check

While at it, ran a script across every `.md` in the repo cross-referencing local image refs against the actual files on disk. **This was the only remaining broken local image**; the other 185 references resolve correctly. External image URLs (`printables.com`, `thingiverse.com`, etc.) were ignored as they live outside the repo.

## Test plan

- [ ] Render `index.md` on the live site and confirm the 256KB Decoder card now shows the thumbnail.