### PR TITLE
docs(keyboard): embed Bluetooth-on-Atari-ST YouTube Short on the index page

### DIFF
--- a/sidecartridge-keyboard/index.md
+++ b/sidecartridge-keyboard/index.md
@@ -23,6 +23,16 @@ Because the host computer communicates with a real controller implementation, th
 
 The project currently exists in two hardware variants that share the same firmware base.
 
+<figure class="video_container" style="position: relative; padding-bottom: 140%; height: 0; overflow: hidden; max-width: 420px; margin: 0 auto; background: #000;">
+  <iframe
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;"
+    src="https://www.youtube.com/embed/_OcU2Ypzp1g?iv_load_policy=3&modestbranding=1&playsinline=1&showinfo=0&rel=0&enablejsapi=1"
+    loading="lazy"
+    allowfullscreen
+    allowtransparency>
+  </iframe>
+</figure>
+
 
 ## Hardware variants
 


### PR DESCRIPTION
## Summary

Adds the Croissant Bluetooth demo Short (https://www.youtube.com/shorts/_OcU2Ypzp1g) to the SidecarTridge Keyboard Emulator docs landing page, right after the introductory paragraph that mentions the two hardware variants.

Uses the same vertical `<figure class="video_container">` container with 140% padding-bottom and a 420 px max-width that we already use for the ST2VGA Enhanced short in `st2vga-family/index.md`, so the embed renders correctly in portrait aspect.

The video gives the reader a quick visual of what Croissant does (Bluetooth gamepad on a real Atari ST playing 1943, etc.) before they drop into the `Hardware variants` table.

## Test plan

- [ ] Render `/sidecartridge-keyboard/` and confirm the Short appears between the intro paragraph and the `Hardware variants` section.