### PR TITLE
docs(multidevice): point readers at the new USM web cart builder

### DIFF
--- a/sidecartridge-multidevice/microfirmwares/rom_emulator.md
+++ b/sidecartridge-multidevice/microfirmwares/rom_emulator.md
@@ -25,7 +25,7 @@ This is a microfirmware application for the **SidecarTridge Multi-device**, desi
 A list of available ROM files can be found in the [ROMs repository](https://sidecartridge.com/roms/). In a standard ROM emulation setup, ROMs can be downloaded directly using the **[D]ownload** option in the setup screen. When using headless autorun mode, ROM files must typically be copied manually to the microSD card from your computer.
 
 {: .note }
-**Want to turn your own Atari ST program into a cartridge ROM?** Use the [SidecarTridge USM web app](https://usm.sidecartridge.com) to pack any `.PRG` or `.TOS` file into a 128 KB `.ROM` image in your browser. Drop the resulting `.ROM` onto the microSD card in the `/roms` folder and the ROM Emulator microfirmware will run it as if it came from a physical cart. USM-web is a browser port of [ggnkua's USM tool](https://github.com/sidecartridge/USM); the source for the web version is at [`sidecartridge/USM-web`](https://github.com/sidecartridge/USM-web).
+**Want to turn your own Atari ST program into a cartridge ROM?** Use the [SidecarTridge USM web app](https://usm.sidecartridge.com) to pack any `.PRG` or `.TOS` file into a 128 KB `.ROM` image in your browser, then drop it onto the microSD card in the `/roms` folder and the ROM Emulator microfirmware will run it like a physical cart.
 
 <details open markdown="block">
   <summary>

--- a/sidecartridge-multidevice/microfirmwares/rom_emulator.md
+++ b/sidecartridge-multidevice/microfirmwares/rom_emulator.md
@@ -24,6 +24,9 @@ This is a microfirmware application for the **SidecarTridge Multi-device**, desi
 {: .note }
 A list of available ROM files can be found in the [ROMs repository](https://sidecartridge.com/roms/). In a standard ROM emulation setup, ROMs can be downloaded directly using the **[D]ownload** option in the setup screen. When using headless autorun mode, ROM files must typically be copied manually to the microSD card from your computer.
 
+{: .note }
+**Want to turn your own Atari ST program into a cartridge ROM?** Use the [SidecarTridge USM web app](https://usm.sidecartridge.com) to pack any `.PRG` or `.TOS` file into a 128 KB `.ROM` image in your browser. Drop the resulting `.ROM` onto the microSD card in the `/roms` folder and the ROM Emulator microfirmware will run it as if it came from a physical cart. USM-web is a browser port of [ggnkua's USM tool](https://github.com/sidecartridge/USM); the source for the web version is at [`sidecartridge/USM-web`](https://github.com/sidecartridge/USM-web).
+
 <details open markdown="block">
   <summary>
     Table of contents

--- a/sidecartridge-multidevice/publicromdb.md
+++ b/sidecartridge-multidevice/publicromdb.md
@@ -32,6 +32,9 @@ All ROMs are available for download clicking on the links. The files are not hos
 
 ## How to contribute
 
+{: .note }
+If you have an Atari ST program (`.PRG` / `.TOS`) and you want to publish it as a cartridge ROM, you can build the `.ROM` (or `.STC` for STEem) in your browser with the [SidecarTridge USM web app](https://usm.sidecartridge.com) and then submit the resulting file through the contribution flow below.
+
 If you have a ROM image that is not listed here, you can contribute to the database by submitting a pull request with the following information:
 
 - Name of the ROM

--- a/sidecartridge-multidevice/userguide.md
+++ b/sidecartridge-multidevice/userguide.md
@@ -32,6 +32,9 @@ This page documents the SidecarTridge Multi-device with **firmware v1.0**, which
 
 ROM Emulation is a pivotal feature of the Multi-device, enabling the Atari ST to treat ROM files from a microSD card or an external web server as native ROM chips. This guide covers how use and set up the ROM Emulation.
 
+{: .note }
+If you want to turn your own Atari ST program into a cartridge ROM image, use the [SidecarTridge USM web app](https://usm.sidecartridge.com): drop a `.PRG` or `.TOS` file in your browser and download a ready-to-use 128 KB `.ROM` that this firmware can boot like a real cartridge.
+
 ### Select the ROM to emulate
 
 The Multi-device can be configured to emulate a ROM file from a microSD card or an external web server. This section explains how to select the ROM to emulate in both cases. 


### PR DESCRIPTION
## Summary

A new browser-based tool, **USM-web** (https://usm.sidecartridge.com), lets users pack their own Atari ST `.PRG` / `.TOS` programs into 128 KB cartridge `.ROM` images that the Multi-device ROM Emulator can boot like a real cart. Surfaced the tool in three places where a reader would naturally look for it.

## Changes

- **`microfirmwares/rom_emulator.md`**: added a follow-up `.note` callout right after the existing list-of-ROMs note. Explains that USM-web can build a `.ROM` from a `.PRG` / `.TOS`, with a pointer to the `/roms` folder and to ggnkua's upstream USM tool.
- **`userguide.md`** (V1 ROM Emulation section): short `.note` callout under the intro paragraph pointing at USM-web. The V1 user guide is flagged as deprecated, but readers still land there via search, so the one-line cross-link earns its place.
- **`publicromdb.md`** (How to contribute): added a `.note` above the contribution requirements so a contributor with a `.PRG` knows they can build the `.ROM` (or `.STC` for STEem) in the browser first before opening a PR to the public ROM database. This is the suggested extra spot.

USM-web source: https://github.com/sidecartridge/USM-web

## Test plan

- [ ] Render the three changed pages and confirm the USM-web link is reachable and the surrounding wording reads cleanly.