### PR TITLE
docs: clarify TOS Emulator and 256KB Decoder support scope for modified machines

### DIFF
--- a/sidecartridge-tos-256kb-decoder/before-buy.md
+++ b/sidecartridge-tos-256kb-decoder/before-buy.md
@@ -49,6 +49,8 @@ Modding a 35 to 40 year old computer is never completely risk free. Even if inst
 
 These machines are fragile, and sometimes a simple slip can be fatal. If you decide to mod an Atari Mega ST, do it with patience, the right tools, and the understanding that this is part of the process. That is the art of modding.
 
+The same principle applies in reverse: we only design, test and support the SidecarTridge TOS 256KB Decoder on Mega ST motherboards in their original stock configuration, with the standard Atari Blitter patch as the single supported exception. Any other prior modification (memory expansions, CPU accelerators, custom logic replacements, bodge wires, aftermarket ROM adapters) is out of scope and not covered by warranty. If your Mega ST has already been modified, please contact us before ordering so we can tell you whether the configuration is known to work.
+
 
 
 [Previous: Introduction](/sidecartridge-tos-256kb-decoder/introduction/){: .btn .mr-4 }

--- a/sidecartridge-tos/faq.md
+++ b/sidecartridge-tos/faq.md
@@ -26,6 +26,12 @@ Incompatibility usually arises from the lack of a carrier board that supports th
 
 Potentially yes, but it is best to inquire first. For unique or unknown motherboards, contact us to discuss compatibility and the possibility of developing a carrier board for it.
 
+### Can I use the SidecarTridge TOS Emulator with modified computers or CPU accelerators?
+
+The TOS Emulator is designed, tested and supported on Atari ST, STE, MegaST and MegaSTE computers in their original stock configuration. Modified machines, including memory expansions, CPU accelerators, custom logic replacements, bodge wires and aftermarket ROM adapters, are out of scope and not covered by warranty. The only exception is the standard Atari Blitter patch on the Mega ST, which remains supported.
+
+If your machine is modified, please contact us before ordering. Some users report that certain CPU accelerator setups work in combination with the TOS Emulator, but such configurations are unsupported and used entirely at your own risk.
+
 ### Why is the SidecarTridge TOS emulator limited to 256KB ROMs maximum?
 
 This is a limitation of the RP2040 microcontroller used in the v1 and v2 versions of the SidecarTridge ROM emulator. The RP2040 has a maximum address space of 256KB, which means it can only address up to 256KB of ROM memory.


### PR DESCRIPTION
## Summary

Mirror in the docs site the same scoping language just merged on the product pages (sidecartridge.github.io PR #45).

- `sidecartridge-tos/faq.md`: add a new entry inside `## General Questions`, right after the existing entry about motherboards not listed as supported.
- `sidecartridge-tos-256kb-decoder/before-buy.md`: extend the existing `### A final note about The Art of Modding` section with a third paragraph that complements the modding warning by stating the device's support scope (stock Mega ST + Atari Blitter patch only).

## Test plan

- [ ] Local Jekyll build renders both updated pages correctly.
- [ ] Wording matches the product-page FAQ entries on sidecartridge.com.