### PR TITLE
Fix invisible nav buttons in docs color scheme

### DIFF
--- a/_sass/color_schemes/sidecartridge.scss
+++ b/_sass/color_schemes/sidecartridge.scss
@@ -68,9 +68,13 @@ $body-text-color: $brand-indigo;
 $body-heading-color: $brand-indigo;
 
 // Links and buttons
+// Note: $btn-primary-color and $base-button-color are the button BACKGROUND
+// (not the text), so they must contrast with the body text color (indigo).
+// We use cream-2 so the button reads as a light pill with indigo text and
+// the same surface family as the rest of the scheme.
 $link-color: $brand-indigo;
-$btn-primary-color: $brand-indigo;
-$base-button-color: $brand-indigo;
+$btn-primary-color: $brand-cream-2;
+$base-button-color: $brand-cream-2;
 
 // Nav (left sidebar tree)
 $nav-child-link-color: $brand-indigo-2;
@@ -93,4 +97,25 @@ $search-result-preview-color: $brand-indigo-2;
 .side-bar nav .nav-list-link[aria-current="page"] {
   border-left: 3px solid $brand-peach;
   padding-left: calc(0.75rem - 3px);
+}
+
+// Belt-and-suspenders contrast for in-page navigation buttons. just-the-docs
+// uses a few classes for the previous/next page links and the on-page
+// utility buttons; force indigo text on the cream surface across all of
+// them and add a thin indigo border so the pill always reads as a button.
+.btn,
+.btn-primary,
+.btn-outline,
+.site-button,
+.search-button,
+.aux-nav-list-link,
+.navigation-list-link,
+.toc-link {
+  color: $brand-indigo;
+}
+
+.btn,
+.btn-primary,
+.btn-outline {
+  border: 1px solid $brand-indigo;
 }


### PR DESCRIPTION
PR #81 set `$btn-primary-color` and `$base-button-color` to deep indigo on the (wrong) assumption that they controlled button text. They actually control the button **background**. With the body text color also indigo, buttons rendered indigo-on-indigo and the labels disappeared. Most visible on the previous / next page navigation at the bottom of every docs page.

**Fix**

- Flip `$btn-primary-color` and `$base-button-color` to cream-2 so the button surface contrasts with the indigo text inherited from body.
- Add an explicit `color: indigo` rule for `.btn`, `.btn-primary`, `.btn-outline`, `.site-button`, `.search-button`, `.aux-nav-list-link`, `.navigation-list-link`, and `.toc-link` as a belt-and-suspenders guard against future inheritance drift across just-the-docs minor versions.
- Add a thin 1px indigo border on `.btn` variants so each pill always reads as a button rather than a tinted text block.

**Files**

- `_sass/color_schemes/sidecartridge.scss` — variable corrections plus the explicit selectors.
