### PR TITLE
Fix unreadable callouts and code blocks by raising specificity

### DIFF
--- a/_sass/color_schemes/sidecartridge.scss
+++ b/_sass/color_schemes/sidecartridge.scss
@@ -130,10 +130,20 @@ $search-result-preview-color: $brand-indigo-2;
 // We element-scope each callout (p.<name>, ul.<name>, etc.) because Rouge
 // also emits a div.highlight wrapper for fenced code blocks; a bare
 // .highlight selector would repaint code blocks by mistake.
+//
+// All callout rules are nested inside .main-content so they outrank the
+// just-the-docs auto-generated callout rules (`p.important, blockquote.important
+// { background: rgba($blue-100, ...); }`) that the theme injects from the
+// callouts config in _config.yml. Those rules use bare `p.important` selectors
+// (specificity 0,1,1) and appear later in the cascade, so without a parent
+// prefix they win and our bg/border get overridden while our text color
+// survives — leaving cream text on the theme's light-blue surface
+// (unreadable). .main-content bumps every nested rule to (0,2,1) so we
+// reliably win the cascade.
 
-$callout-elements: "p, ul, ol, blockquote, dl";
+.main-content {
 
-#{$callout-elements} {
+#{"p, ul, ol, blockquote, dl"} {
   &.highlight,
   &.note,
   &.new,
@@ -220,10 +230,19 @@ $callout-elements: "p, ul, ol, blockquote, dl";
   }
 }
 
+} // end .main-content
+
 // --- Code blocks ------------------------------------------------------------
 // "PCB module" treatment: deep indigo surface, cream Fira Mono text, a thin
 // peach hairline border, and a language label pill in the top-right corner
 // that mirrors a silkscreen component label.
+//
+// Wrapped in .main-content for the same cascade reason as the callouts
+// above: just-the-docs ships a bare `div.highlighter-rouge { background-color
+// ... }` rule later in the cascade that would otherwise repaint the indigo
+// surface back to the body code-background. .main-content makes us win.
+
+.main-content {
 
 div.highlighter-rouge,
 figure.highlight {
@@ -378,3 +397,5 @@ $rouge-peach-dim: rgba($brand-peach, 0.7);
   .gi { color: $rouge-peach; background-color: rgba($brand-peach, 0.1); }
   .err { color: $rouge-peach; text-decoration: underline wavy rgba($brand-peach, 0.7); }
 }
+
+} // end .main-content (code blocks)


### PR DESCRIPTION
## Summary

Bug introduced by PR #83 and visible on docs.sidecartridge.com right now: the IMPORTANT and WARNING callouts render with cream (near-white) text on a light-blue surface, completely unreadable.

### Root cause

PR #83 styled the five callouts (` highlight / note / new / important / warning`) and code blocks with selectors at specificity (0,1,1):

```
:is(p, ul, ol, blockquote, dl).important { background-color: #3b364c; color: #fdfcf9; ... }
```

just-the-docs auto-generates a callout block from the ` callouts:` config in ` _config.yml` and emits it later in the compiled stylesheet:

```
p.important, blockquote.important { background: rgba(44, 132, 250, 0.2); border-left: 4px solid #183385; ... }
```

Same specificity (0,1,1), source-order wins → the theme's light-blue background and blue border override mine. But the theme rule does not redefine ` color`, so the cream text from PR #83 survives. Cream on light-blue = no contrast.

Same issue affects code blocks: ` div.highlighter-rouge { background-color: #f7f6ed; ... }` appears later in the cascade and would repaint the indigo PCB surface back to the body code-background.

### Fix

Wrap every callout and code-block rule inside a single ` .main-content { ... }` parent (the canonical just-the-docs page wrapper). That bumps the nested selectors to (0,2,1), which beats both theme rules reliably without any ` !important` hacks or selector contortions.

No palette changes, no selector logic changes. Pure cascade fix.

### Compilation

SCSS still compiles clean, no Sass warnings, 77 ` .main-content`-prefixed rules in the generated CSS.

## Test plan

- [ ] Preview deploy builds without errors
- [ ] Reopen ` sidecartridge-multidevice/getting_started_v2` (or any page with a ` .important` callout) — body text reads cream on the dark indigo-2 surface with peach trace and peach pill, fully legible
- [ ] ` .warning` callouts on ` sidecartridge-tos/hardware-installation` render with peach trace, peach pill, cream body on full indigo
- [ ] Code blocks across languages render with the indigo PCB surface (not cream-2) and the peach language pill in the top-right corner
- [ ] Rouge syntax tokens (keywords, strings, numbers) use the two-tone cream/peach palette and not the default high-contrast rainbow
- [ ] Inline ` code` inside body text still reads on cream-2 (lighter surface), confirming we did not over-bump that one