### PR TITLE
Restore red on .warning callouts

### DIFF
--- a/_sass/color_schemes/sidecartridge.scss
+++ b/_sass/color_schemes/sidecartridge.scss
@@ -50,6 +50,13 @@ $brand-cream: #fdfcf9;
 $brand-cream-2: #f7f6ed;
 $brand-peach: #faebd7;
 
+// Brick-red accent used only on .warning callouts. Kept outside the five-token
+// brand core on purpose: the universal red = danger convention beats palette
+// purity for safety-critical signage. Chosen as a warm, desaturated brick so
+// it sits next to peach without screaming like #ff0000.
+$brand-warning: #c44848;
+$brand-warning-dark: #9a3838;
+
 // --- Just-the-docs variable overrides ---------------------------------------
 // Names match the just-the-docs 0.8.x public SCSS API. Anything not
 // overridden inherits the upstream defaults.
@@ -205,30 +212,36 @@ $search-result-preview-color: $brand-indigo-2;
   color: $brand-indigo;
 }
 
-// Warning — same inversion as important but on full indigo with a thicker
-// peach trace so it reads as one notch louder.
+// Warning — brick red surface, the only callout that breaks out of the brand
+// palette. The universal red = danger convention outranks palette purity for
+// safety-critical signage. Pill is inverted (cream bg, red text) so "WARNING"
+// pops above the red surface.
 :is(p, ul, ol, blockquote, dl).warning {
-  background-color: $brand-indigo;
+  background-color: $brand-warning;
   color: $brand-cream;
   border-left-width: 4px;
-  border-left-color: $brand-peach;
+  border-left-color: $brand-warning-dark;
 }
 :is(p, ul, ol, blockquote, dl).warning::before {
-  background-color: $brand-peach;
-  color: $brand-indigo;
+  background-color: $brand-cream;
+  color: $brand-warning;
 }
 
 // Inside the inverted callouts, keep emphasis and inline code legible
-// against the indigo surface.
+// against the dark / red surfaces.
 :is(p, ul, ol, blockquote, dl):is(.important, .warning) {
   strong { color: $brand-cream; }
-  a { color: $brand-peach; text-decoration: underline; }
+  a { text-decoration: underline; }
   code {
     color: $brand-cream;
     background-color: rgba($brand-cream, 0.08);
     border-color: rgba($brand-cream, 0.2);
   }
 }
+// Link colour differs per surface: peach reads well on indigo (.important);
+// on the warning brick red, peach loses contrast, so links go full cream.
+:is(p, ul, ol, blockquote, dl).important a { color: $brand-peach; }
+:is(p, ul, ol, blockquote, dl).warning a { color: $brand-cream; }
 
 } // end .main-content
 


### PR DESCRIPTION
## Summary

PR #83 styled the five callouts strictly inside the five-token brand palette (indigo / indigo-2 / cream / cream-2 / peach), differentiating severity by structure (border weight, inversion) instead of by colour. That worked for note / highlight / new / important but broke ` .warning`: with no red, the universal *red = danger* signal disappeared. A warning callout at first glance read like just another strong note.

This PR brings red back, scoped only to ` .warning`.

### New tokens (warning only)

```scss
$brand-warning:      #c44848;  // warm brick red, sits next to peach without shouting like #ff0000
$brand-warning-dark: #9a3838;  // left-border trim, slightly darker
```

These deliberately live outside the five-token brand core because the *red = danger* convention outranks palette purity for safety signage.

### Per-element changes inside ` .warning`

| Element       | Before                    | After                          |
|---------------|---------------------------|--------------------------------|
| Surface       | indigo ` #0d042b`         | brick red ` #c44848`           |
| Left border   | 4px peach                 | 4px brick-red-dark ` #9a3838`  |
| Pill bg       | peach                     | cream ` #fdfcf9`               |
| Pill text     | indigo                    | brick red ` #c44848`           |
| Body text     | cream (unchanged)         | cream                          |
| Links         | peach                     | cream (peach loses contrast against red) |
| ` strong`     | cream (unchanged)         | cream                          |
| Inline ` code`| ` rgba(cream, 0.08)` (unchanged) | same                    |

` .important` is unchanged: it keeps the indigo-2 surface + peach trace + peach links because peach reads well on indigo and ` .important` ≠ ` .warning` in semantics.

## Test plan

- [ ] Preview deploy builds cleanly
- [ ] Any page with a ` .warning` callout (e.g. ` sidecartridge-tos/hardware-installation`) renders with brick-red surface and inverted pill
- [ ] ` .important` callouts still render with indigo-2 surface and peach pill (no regression)
- [ ] Links inside a ` .warning` are cream and underlined, easy to spot
- [ ] No other callouts changed visually