### PR TITLE
Brand sidebar wordmark and search box

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: SidecarTridge Docs
+logo: "/assets/images/SIDECARTRIDGE_TEXT_1920x416_BLACK.png"
 description: SidecarTridge Products Documentation site
 domain: docs.sidecartridge.com
 baseurl: "" # the subpath of your site, e.g. /blog

--- a/_includes/search_placeholder_custom.html
+++ b/_includes/search_placeholder_custom.html
@@ -1,0 +1,1 @@
+Search docs

--- a/_sass/color_schemes/sidecartridge.scss
+++ b/_sass/color_schemes/sidecartridge.scss
@@ -412,3 +412,61 @@ $rouge-peach-dim: rgba($brand-peach, 0.7);
 }
 
 } // end .main-content (code blocks)
+
+// --- Sidebar wordmark logo --------------------------------------------------
+// The theme renders `<div class="site-logo">` when `logo:` is set in
+// _config.yml and pulls the URL via a Sass variable interpolated at build
+// time. The default sizing assumes a small square favicon-ish logo; the
+// SidecarTridge wordmark is 1920x416 (~4.6:1), so it needs a wider canvas.
+
+.site-title {
+  padding: $sp-3 0;
+}
+
+.site-logo {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  background-position: left center;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+// --- Search box -------------------------------------------------------------
+// Fira Mono placeholder, thin indigo hairline, peach focus accent. The
+// theme uses bare `.search-input` selectors with low specificity, so a
+// straight class selector wins here without any wrapper boost.
+
+.search-input {
+  font-family: $body-font-family;
+  color: $brand-indigo;
+  background-color: $brand-cream;
+  border: 1px solid rgba($brand-indigo, 0.2);
+  border-radius: 4px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+  &::placeholder {
+    font-family: $mono-font-family;
+    font-size: 0.85em;
+    letter-spacing: 0.04em;
+    color: rgba($brand-indigo, 0.5);
+  }
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+    border-color: $brand-peach;
+    box-shadow: 0 0 0 2px rgba($brand-peach, 0.6);
+  }
+}
+
+.search-icon {
+  fill: rgba($brand-indigo, 0.55);
+}
+
+// Lift the dropdown of search results so it visually anchors to the input.
+.search-results {
+  border: 1px solid rgba($brand-indigo, 0.15);
+  border-top: 0;
+  background-color: $brand-cream;
+}


### PR DESCRIPTION
## Summary

Picks up items 5 and 6 of the original docs.sidecartridge.com brand plan, after #81 (color scheme + typography), #83 (callouts + code blocks), #84 (specificity fix), and #85 (red on .warning).

### Item 5 — wordmark in the sidebar

Replaces the bare 'SidecarTridge Docs' text in the sidebar header with the SidecarTridge wordmark.

- ` _config.yml`: add ` logo: "/assets/images/SIDECARTRIDGE_TEXT_1920x416_BLACK.png"`. just-the-docs ships a ` _includes/title.html` that, when ` site.logo` is set, swaps the title text for ` <div class=\"site-logo\">` driven by a Sass-interpolated background image. Zero include overrides needed.
- ` _sass/color_schemes/sidecartridge.scss`: override ` .site-title` padding and ` .site-logo` dimensions so the 1920×416 wordmark renders at 4.6:1 ratio filling the sidebar header at ~44px tall, left-aligned. The default ` .site-logo` assumes a small square favicon.

Asset choice: the BLACK wordmark variant ships as 1920×416 PNG with alpha (transparent background, black text), which sits cleanly on the cream sidebar. The other wordmark (` SIDECART_TEXT_BW_1920x416.png`) is a full BW raster that would clash with the cream surface.

### Item 6 — search box with personality

- ` _includes/search_placeholder_custom.html`: just-the-docs reads the placeholder from this include. New file ships ' Search docs' to replace the default ' Search'.
- ` _sass/color_schemes/sidecartridge.scss`: search input gets a thin indigo hairline border, cream background, Fira Mono placeholder (smaller, dimmer, wider letter-spacing). Focus state swaps the border to peach and adds a 2px peach-tinted glow ring instead of the default OS focus outline. Search icon picks up an indigo wash. Results dropdown gets a matching hairline border below the input so it visually anchors when typing.

### What's not in scope

Item 7 (minimal footer) is intentionally deferred to a follow-up PR.

## Test plan

- [ ] Sidebar shows the SidecarTridge wordmark (black on cream), left-aligned, at a comfortable height (~44px). On mobile, the wordmark still fits the collapsed header.
- [ ] Search input shows ' Search docs' in Fira Mono before typing, indigo text in DM Sans while typing.
- [ ] Clicking the search input swaps the border colour from indigo-faded to peach and adds a soft peach glow ring.
- [ ] Sidebar nav, callouts, code blocks all unchanged.