### PR TITLE
Brand the docs footer and the home support card

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,7 +91,7 @@ nav_external_links:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "<span>© 2024-25 GOODDATA LABS SL | Looking for support? <a href='mailto:support@gooddatalabs.com'>Email us</a>.</span>"
+footer_content: "<span>© 2024-25 GOODDATA LABS SL · Looking for support? <a href='mailto:support@gooddatalabs.com'>Email us</a>.</span>"
 
 # Footer last edited timestamp
 last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter

--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,1 @@
+Docs for SidecarTridge devices · <a href="https://sidecartridge.com">Back to sidecartridge.com &rarr;</a>

--- a/_sass/color_schemes/sidecartridge.scss
+++ b/_sass/color_schemes/sidecartridge.scss
@@ -470,3 +470,98 @@ $rouge-peach-dim: rgba($brand-peach, 0.7);
   border-top: 0;
   background-color: $brand-cream;
 }
+
+// --- Footer chrome ----------------------------------------------------------
+// Re-style the just-the-docs footer block: Back to top, footer_content,
+// Edit this page on GitHub, and the branded nav_footer_custom line. All in
+// small-caps Fira Mono on indigo so the footer reads as a quiet signature
+// instead of as another paragraph.
+
+.main-content footer {
+  font-family: $mono-font-family;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  color: rgba($brand-indigo, 0.7);
+
+  p { margin: 0 0 $sp-2; }
+
+  a {
+    color: $brand-indigo;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+
+    &:hover {
+      color: $brand-warning;
+    }
+  }
+
+  hr {
+    border: 0;
+    border-top: 1px solid rgba($brand-indigo, 0.12);
+    margin: $sp-5 0 $sp-3;
+  }
+}
+
+// The hyperlink utility-row classes JTD ships uppercase nicely.
+#back-to-top,
+#edit-this-page {
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  text-decoration: none;
+
+  &::after { content: " \2197"; opacity: 0.6; }
+}
+
+#back-to-top::after { content: " \2191"; }
+
+// The sidebar's bottom block (desktop) and the mobile-only nav_footer_custom
+// block in the page footer both pull from _includes/nav_footer_custom.html.
+.site-footer,
+.main-content footer .d-md-none {
+  font-family: $mono-font-family;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  color: rgba($brand-indigo, 0.65);
+
+  a {
+    color: $brand-indigo;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+
+    &:hover { color: $brand-warning; }
+  }
+}
+
+// --- Home support card and email CTA pill ----------------------------------
+// The .support-note block lives on the home page; convert the mail link into
+// a peach pill with indigo text so the CTA reads as a CTA instead of a flat
+// underlined link.
+
+.support-note {
+  margin: $sp-5 0 $sp-4;
+  padding: $sp-4 $sp-5;
+  background-color: $brand-cream-2;
+  border-radius: 10px;
+  text-align: center;
+  font-size: 1rem;
+  color: $brand-indigo;
+
+  a[href^="mailto:"] {
+    display: inline-block;
+    margin: 0 0.15em;
+    padding: 0.2em 0.85em;
+    background-color: $brand-peach;
+    color: $brand-indigo;
+    border-radius: 999px;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background-color 0.15s ease, transform 0.15s ease;
+
+    &:hover {
+      background-color: #f1dcb7; // brand-peach darkened ~6% (precomputed to avoid darken() deprecation)
+      transform: translateY(-1px);
+    }
+  }
+}

--- a/index.md
+++ b/index.md
@@ -68,15 +68,6 @@ has_toc: false
     font-size: .95rem;
     color: #333;
   }
-  .support-note {
-    margin-top: 2rem;
-    padding: 1rem;
-    background: #f1f3f5;
-    border-radius: 10px;
-    text-align: center;
-    font-size: 1rem;
-    color: #222;
-  }
 </style>
 
 <div class="proj-list">


### PR DESCRIPTION
## Summary

Closes item 7 (footer minimal) from the docs.sidecartridge.com brand plan, after #81 / #83 / #84 / #85 / #86.

### Footer chrome (page bottom)

- ` _config.yml`: ` footer_content` separator changes from ` |` to ` ·`, so the line reads as a single quiet sentence instead of two clauses.
- ` _sass/color_schemes/sidecartridge.scss`: footer paragraph drops to **Fira Mono small** at ` 0.78rem` on a dim indigo. The ` #back-to-top` and ` #edit-this-page` anchors become uppercased Fira Mono with directional arrows (` ↑` for back-to-top, ` ↗` for edit-on-GitHub). Footer links underline on hover and pick up the warning brick red so the hover state matches the rest of the brand interactive set.

### Sidebar / mobile footer signature

- ` _includes/nav_footer_custom.html` (new): replaces the upstream ` This site uses Just the Docs, a documentation theme for Jekyll.` with:

  > Docs for SidecarTridge devices · Back to sidecartridge.com →

  just-the-docs renders ` nav_footer_custom` in the sidebar bottom on desktop and at the bottom of the page footer on mobile, so this one file covers both surfaces.

### Home support card and CTA pill

- ` index.md`: drops the inline ` <style>` rule for ` .support-note` (was hard-coded ` #f1f3f5 / #222`). Styling moves to the color scheme so any future use of ` .support-note` picks up the same look without page-level CSS.
- ` _sass/color_schemes/sidecartridge.scss`: ` .support-note` picks up the cream-2 surface with indigo text. The ` mailto:` link inside becomes a **peach pill with indigo text**, 999px border radius, lift-on-hover. The CTA now reads as a button instead of a flat underlined link, while the surrounding sentence stays soft.

### Out of scope

The previously listed items 1-7 are all done after this PR.

## Test plan

- [ ] Page footer: small Fira Mono ` © 2024-25 GOODDATA LABS SL · Looking for support? Email us.` with the email as an underlined link
- [ ] ` ↑ BACK TO TOP` and ` ↗ EDIT THIS PAGE ON GITHUB` render in Fira Mono uppercase
- [ ] Sidebar bottom (desktop) shows the new ` Docs for SidecarTridge devices · Back to sidecartridge.com →` line, no Just-the-docs credit
- [ ] On mobile, that same line shows at the bottom of the page footer
- [ ] Home page ` .support-note` card has cream-2 background, the ` Drop us an email` link is a peach pill, lifts on hover
- [ ] All other pages unchanged (callouts, code blocks, sidebar wordmark, search box still as they were after #86)