### PR TITLE
Align docs naming with the latest product website renames

### DIFF
--- a/index.md
+++ b/index.md
@@ -84,20 +84,20 @@ has_toc: false
 
   <div class="proj-card">
     <div class="proj-inner">
-      <img class="proj-thumb" src="/sidecartridge-psu/assets/images/psu_kit_top-thumbnail.png" alt="SidecarTridge PSU thumbnail">
+      <img class="proj-thumb" src="/sidecartridge-psu/assets/images/psu_kit_top-thumbnail.png" alt="SidecarTridge Mean Well PSU Kit thumbnail">
       <div>
-        <h2><a href="/sidecartridge-psu/">SidecarTridge PSU for Atari ST/MegaST/STE</a></h2>
-        <p>A modern, solderless replacement power supply unit designed for Atari ST, STE and MegaST computers.</p>
+        <h2><a href="/sidecartridge-psu/">SidecarTridge Mean Well PSU Kit</a></h2>
+        <p>A modern, solderless replacement power supply kit based on the Mean Well RPD-60, for Atari ST, STE and Mega ST computers.</p>
       </div>
     </div>
   </div>
 
   <div class="proj-card">
     <div class="proj-inner">
-      <img class="proj-thumb" src="/sidecartridge-usb-c-pd-psu/assets/images/USB-C-PD-BOARD.png" alt="SidecarTridge USB-C PD Multi-Rail Power Supply Unit thumbnail">
+      <img class="proj-thumb" src="/sidecartridge-usb-c-pd-psu/assets/images/USB-C-PD-BOARD.png" alt="SidecarTridge Internal USB-C PD PSU thumbnail">
       <div>
-        <h2><a href="/sidecartridge-usb-c-pd-psu/">SidecarTridge USB-C PD Multi-Rail Power Supply</a></h2>
-        <p>A modern USB-C PD Multi-Rail PSU drop-in replacement for Atari ST/STE/MegaST and Amiga computers</p>
+        <h2><a href="/sidecartridge-usb-c-pd-psu/">SidecarTridge Internal USB-C PD PSU for Atari ST/STE/Mega ST</a></h2>
+        <p>A modern USB-C PD multi-rail PSU drop-in replacement for Atari ST, STE, Mega ST and Amiga computers.</p>
       </div>
     </div>
   </div>
@@ -124,10 +124,10 @@ has_toc: false
 
   <div class="proj-card">
     <div class="proj-inner">
-      <img class="proj-thumb" src="/acsi2stm-atari-st/assets/images/ACSI2STM2-TOP-CONNECTOR.png" alt="ACSI2STM HD thumbnail">
+      <img class="proj-thumb" src="/acsi2stm-atari-st/assets/images/ACSI2STM2-TOP-CONNECTOR.png" alt="ACSI2STM Compact thumbnail">
       <div>
-        <h2><a href="/acsi2stm-atari-st/">ACSI2STM Hard Disk for ST/MegaST/STE/MegaSTE</a></h2>
-        <p>A modern hard disk device for Atari ST/MegaST/STE/MegaSTE.</p>
+        <h2><a href="/acsi2stm-atari-st/">ACSI2STM Compact</a></h2>
+        <p>Modern ACSI hard disk emulator for Atari ST, STE, Mega ST and Mega STE, based on the upstream open-source ACSI2STM project.</p>
       </div>
     </div>
   </div>
@@ -166,8 +166,8 @@ has_toc: false
     <div class="proj-inner">
       <img class="proj-thumb" src="/st2vga-family/assets/images/ST2VGA-REV3-FRONT.png" alt="ST2VGA family thumbnail">
       <div>
-        <h2><a href="/st2vga-family/">ST2VGA family (Rev.3 & Enhanced)</a></h2>
-        <p>Clean VGA output for Atari ST/STE/Mega ST/Mega STE: passive Rev.3 and the active Enhanced model for difficult video stages.</p>
+        <h2><a href="/st2vga-family/">ST2VGA family (Adapter & Enhanced Adapter)</a></h2>
+        <p>Clean VGA output for Atari ST, STE, Mega ST and Mega STE: passive ST2VGA Adapter and the active ST2VGA Enhanced Adapter for difficult video stages.</p>
       </div>
     </div>
   </div>

--- a/sidecartridge-keyboard/before-buy.md
+++ b/sidecartridge-keyboard/before-buy.md
@@ -26,13 +26,13 @@ Use this chapter as a step-by-step checklist to decide which SidecarTridge Keybo
 Choose the hardware variant that matches your Atari computer.
 
 - **Croissant (internal)**  
-  For Atari ST and Atari STe computers with an internal power supply and the internal 7-pin keyboard connector.
+  For Atari ST and Atari STE computers with an internal power supply and the internal 7-pin keyboard connector.
 
 {: .warning}
 Croissant does not work on Atari ST motherboards C070115 and C070243. These "short ST" machines use an 18-pin keyboard connector instead, and they are easy to recognize because they have an external power supply.
 
 - **Soufflè (external dongle)**  
-  For Atari Mega ST and Atari Mega STe computers with the RJ12 keyboard connector on the left side of the computer.
+  For Atari Mega ST and Atari Mega STE computers with the RJ12 keyboard connector on the left side of the computer.
 
 
 ## Step 2: Understand the installation impact
@@ -47,7 +47,7 @@ Before buying, make sure you are comfortable with how each variant is installed.
   Plug the device RJ11 cable into the computer RJ12 connector and the hardware installation is complete.
 
   As a practical recommendation, avoid very power-hungry USB keyboards or accessories.  
-  All USB devices connected to Soufflè are powered from the Atari Mega ST / Mega STe 5V rail, so a stable power supply is important.
+  All USB devices connected to Soufflè are powered from the Atari Mega ST / Mega STE 5V rail, so a stable power supply is important.
 
 
 ## Step 3: Check the supported devices first

--- a/sidecartridge-keyboard/croissant-open-hardware.md
+++ b/sidecartridge-keyboard/croissant-open-hardware.md
@@ -11,7 +11,7 @@ parent: SidecarTridge Keyboard
 
 This page collects the released hardware design files for **SidecarTridge Croissant**, including the diagram, schematics, PCB manufacturing data, assembly files, and licensing information.
 
-The material published here applies to the **Croissant** internal Atari ST / Atari STe keyboard emulator board.
+The material published here applies to the **Croissant** internal Atari ST / Atari STE keyboard emulator board.
 
 <details open markdown="block">
   <summary>

--- a/sidecartridge-keyboard/faq.md
+++ b/sidecartridge-keyboard/faq.md
@@ -32,7 +32,7 @@ The Croissant version of the SidecarTridge Keyboard Emulator is built for the 7-
 
 ### What is the difference between Croissant and Soufflè?
 
-Croissant is the internal variant: it installs inside the Atari ST keyboard area, between the motherboard and the original keyboard, so the original case stays closed. Soufflè is the external dongle variant, designed for Atari Mega ST and Mega STe systems, and plugs into the coiled keyboard cable. Both variants share the same firmware base. See the [Introduction](/sidecartridge-keyboard/introduction/) for the full feature breakdown.
+Croissant is the internal variant: it installs inside the Atari ST keyboard area, between the motherboard and the original keyboard, so the original case stays closed. Soufflè is the external dongle variant, designed for Atari Mega ST and Mega STE systems, and plugs into the coiled keyboard cable. Both variants share the same firmware base. See the [Introduction](/sidecartridge-keyboard/introduction/) for the full feature breakdown.
 
 [Previous: Troubleshooting](/sidecartridge-keyboard/troubleshooting/){: .btn .mr-4 }
 [Main](/sidecartridge-keyboard/){: .btn .mr-4 }

--- a/sidecartridge-keyboard/hardware-installation.md
+++ b/sidecartridge-keyboard/hardware-installation.md
@@ -10,7 +10,7 @@ parent: SidecarTridge Keyboard
 
 {: .no_toc }
 
-This chapter explains how to open an Atari ST / STe computer and install the **SidecarTridge Croissant Keyboard Emulator**.
+This chapter explains how to open an Atari ST / STE computer and install the **SidecarTridge Croissant Keyboard Emulator**.
 
 All ST-family machines use a plastic outer case and internal metal shielding.
 Both must be removed to access the keyboard connector on the motherboard.

--- a/sidecartridge-keyboard/index.md
+++ b/sidecartridge-keyboard/index.md
@@ -18,7 +18,7 @@ has_toc: false
 
 The **SidecarTridge Keyboard Emulator** is a hardware device that emulates the original Atari ST IKBD keyboard controller, allowing modern keyboards, mice, and game controllers to be used on Atari ST-family computers while preserving full compatibility with software that expects the original IKBD behavior.
 
-Unlike simple keyboard adapters that only translate keystrokes, the SidecarTridge Keyboard Emulator reproduces the behavior of the HD6301-based IKBD microcontroller used in the Atari ST, STe, Mega ST, Mega STe, and TT.  
+Unlike simple keyboard adapters that only translate keystrokes, the SidecarTridge Keyboard Emulator reproduces the behavior of the HD6301-based IKBD microcontroller used in the Atari ST, STE, Mega ST, Mega STE, and TT.  
 Because the host computer communicates with a real controller implementation, the system behaves as if an original Atari keyboard were connected.
 
 The project currently exists in two hardware variants that share the same firmware base.
@@ -37,13 +37,13 @@ The project currently exists in two hardware variants that share the same firmwa
 ## Hardware variants
 
 - **SidecarTridge Croissant**  
-  Internal adapter for Atari ST and Atari STe computers with the internal 7-pin keyboard connector.  
+  Internal adapter for Atari ST and Atari STE computers with the internal 7-pin keyboard connector.  
   Works as a middle-man between the motherboard and the original keyboard path, allowing Bluetooth, and mixed input configurations while preserving compatibility with original devices.
 
 ![SidecarTridge Croissant internal keyboard emulator](/sidecartridge-keyboard/assets/images/KEYBOARD-EMULATOR-CROISSANT-TOP.png)
 
 - **SidecarTridge Soufflè**  
-  External keyboard replacement for Atari Mega ST and Mega STe systems.  
+  External keyboard replacement for Atari Mega ST and Mega STE systems.  
   Connects in place of the original keyboard and adds Bluetooth and USB input support while maintaining normal IKBD behavior.
 
 ![SidecarTridge Soufflè external keyboard emulator](/sidecartridge-keyboard/assets/images/KEYBOARD-EMULATOR-SOUFFLE-PERSPECTIVE.png)
@@ -73,7 +73,7 @@ Typical use cases for the SidecarTridge Keyboard Emulator include:
 - replacing missing or faulty original keyboards
 - preserving compatibility with software that depends on normal IKBD behavior
 - combining modern input devices with original Atari joysticks and mouse
-- modernizing Atari ST, STe, Mega ST, Mega STe, and TT setups
+- modernizing Atari ST, STE, Mega ST, Mega STE, and TT setups
 
 
 ## Table of Contents

--- a/sidecartridge-keyboard/introduction.md
+++ b/sidecartridge-keyboard/introduction.md
@@ -11,7 +11,7 @@ parent: SidecarTridge Keyboard
 
 The **SidecarTridge Keyboard Emulator** is a hardware device that emulates the original Atari ST IKBD keyboard controller, allowing modern input devices to be used with Atari ST-family computers while maintaining full compatibility with software that expects standard IKBD behavior.
 
-Unlike simple keyboard adapters that translate key presses, the SidecarTridge Keyboard Emulator reproduces the behavior of the HD6301-based IKBD microcontroller used in the Atari ST, STe, Mega ST, Mega STe, and TT.  
+Unlike simple keyboard adapters that translate key presses, the SidecarTridge Keyboard Emulator reproduces the behavior of the HD6301-based IKBD microcontroller used in the Atari ST, STE, Mega ST, Mega STE, and TT.  
 Because the host computer communicates with a real controller implementation, the system behaves as if an original Atari keyboard were connected.
 
 This section introduces the project and explains how the emulator fits into Atari keyboard and input device setups.
@@ -33,9 +33,9 @@ This section introduces the project and explains how the emulator fits into Atar
 The SidecarTridge Keyboard Emulator is designed for Atari computers that use the IKBD keyboard controller architecture, including:
 
 - Atari ST  
-- Atari STe  
+- Atari STE  
 - Atari Mega ST  
-- Atari Mega STe  
+- Atari Mega STE  
 - compatible systems using the same IKBD protocol
 
 By emulating the original keyboard microcontroller instead of only translating keystrokes, the device allows modern input methods while preserving compatibility with software that expects the original IKBD behavior.
@@ -45,7 +45,7 @@ The SidecarTridge Keyboard Emulator currently exists in two hardware variants.
 
 ### SidecarTridge Croissant
 
-SidecarTridge Croissant is an internal adapter for Atari ST and Atari STe computers that use the 7-pin internal keyboard connector.
+SidecarTridge Croissant is an internal adapter for Atari ST and Atari STE computers that use the 7-pin internal keyboard connector.
 
 It works as a middle-man between the motherboard and the keyboard and allows different operating modes, including:
 
@@ -59,7 +59,7 @@ The operating mode can be changed at boot time without opening the computer encl
 
 ### SidecarTridge Soufflè
 
-SidecarTridge Soufflè is an external keyboard replacement for Atari Mega ST and Mega STe systems.
+SidecarTridge Soufflè is an external keyboard replacement for Atari Mega ST and Mega STE systems.
 
 It connects to the computer in place of the original keyboard and provides:
 
@@ -110,14 +110,14 @@ Common reasons to use the SidecarTridge Keyboard Emulator include:
 
 ### Croissant features
 
-- internal middle-man design for Atari ST / STe
+- internal middle-man design for Atari ST / STE
 - pass-through mode for original keyboard and mouse
 - Bluetooth and pass-through mode selectable at boot
 
 
 ### Soufflè features
 
-- external keyboard replacement for Mega ST / Mega STe
+- external keyboard replacement for Mega ST / Mega STE
 - built-in USB hub for keyboards, mice, and gamepads
 - support for original joysticks and mouse together with USB keyboard
 - designed for systems without a working original keyboard

--- a/sidecartridge-keyboard/usb-on-croissant.md
+++ b/sidecartridge-keyboard/usb-on-croissant.md
@@ -27,7 +27,7 @@ This is an experimental setup. It is not validated in production, no specific US
 
 Owners of an Atari **ST** or **STE** with the **7-pin internal keyboard connector** (the Croissant target) who want USB input on their machine and are happy with the trade-offs listed under [Limitations](#limitations) below.
 
-If your machine is a **Mega ST** or **Mega STe**, you do not need this workaround. The dedicated product for those is **Soufflè**, which ships with a built-in USB hub. See the [Introduction](introduction.md) for the variant breakdown.
+If your machine is a **Mega ST** or **Mega STE**, you do not need this workaround. The dedicated product for those is **Soufflè**, which ships with a built-in USB hub. See the [Introduction](introduction.md) for the variant breakdown.
 
 ## How it works
 

--- a/sidecartridge-psu/index.md
+++ b/sidecartridge-psu/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: SidecarTridge Power Supply Unit
+title: SidecarTridge Mean Well PSU Kit
 nav_order: 0
 nav_exclude: false
 toc: false
@@ -8,12 +8,12 @@ has_toc: false
 ---
 
 
-![SidecarTridge PSU kit](/sidecartridge-psu/assets/images/psu_kit_top-1024x768.png)
+![SidecarTridge Mean Well PSU Kit](/sidecartridge-psu/assets/images/psu_kit_top-1024x768.png)
 
-# SidecarTridge Power Supply Unit
+# SidecarTridge Mean Well PSU Kit
 
-The PSU for Atari ST is a modern, solderless replacement power supply unit designed for Atari ST, STE and MegaST computers. Over time, the original PSU components in these vintage systems can deteriorate, leading to unstable voltage output, erratic behavior, or even damage to the motherboard and other internal parts. The PSU for Atari ST addresses these issues by providing a stable and reliable power source, ensuring the longevity and safe operation of your retro computer. It is particularly recommended for SidecarTridge users to avoid failures related to the aging power supply.
+The **SidecarTridge Mean Well PSU Kit** is a modern, solderless replacement power supply kit designed for Atari ST, STE and Mega ST computers. Over time, the original PSU components in these vintage systems can deteriorate, leading to unstable voltage output, erratic behavior, or even damage to the motherboard and other internal parts. The Mean Well PSU Kit addresses these issues by providing a stable and reliable power source, ensuring the longevity and safe operation of your retro computer. It is particularly recommended for SidecarTridge users to avoid failures related to the aging power supply.
 
 This replacement PSU is based on the reliable Mean Well RPD-60, known for its efficiency and stability. The kit includes all necessary components for a straightforward, solderless installation: a custom riser board, connectors, screws, and a specialized cable for seamless connection to the Atari ST motherboard and AC power plug. The riser board ensures the new PSU fits perfectly in the original PSU's location, maintaining the correct alignment and positioning within the computer. This thoughtful design makes the installation process easy and ensures that your Atari ST runs smoothly and reliably for years to come.
 
-You can buy the PSU for Atari ST from the [SidecarTridge store](https://store.sidecartridge.com) and you can learn how to install it by following the [Quickstart](https://sidecartridge.com/quickstart/psu-atari-st/) in the main website.
+You can buy the Mean Well PSU Kit from the [SidecarTridge store](https://store.sidecartridge.com) and you can learn how to install it by following the [Quickstart](https://sidecartridge.com/quickstart/psu-atari-st/) in the main website.

--- a/st2vga-family/index.md
+++ b/st2vga-family/index.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: ST2VGA family (Rev.3 & Enhanced)
+title: ST2VGA family (Adapter & Enhanced Adapter)
 nav_order: 50
 nav_exclude: false
 has_children: true
 ---
 
-# ST2VGA family (Rev.3 & Enhanced)
+# ST2VGA family (Adapter & Enhanced Adapter)
 
 The **ST2VGA** adapters let an Atari ST/STE/Mega ST/Mega STE drive a compatible **multisync VGA display** while preserving the original Atari video timings (this is **not** a scan doubler or scaler).
 


### PR DESCRIPTION
## Summary

Cross-page naming cleanup so the documentation site speaks the same product names as `sidecartridge.com` after the recent web rework (web PRs #71-#90). All URL slugs and image paths are preserved.

## Changes

### Home page (`index.md`)

| Card | Before | After |
|---|---|---|
| PSU | `SidecarTridge PSU for Atari ST/MegaST/STE` | `SidecarTridge Mean Well PSU Kit` |
| USB-C PD PSU | `SidecarTridge USB-C PD Multi-Rail Power Supply` | `SidecarTridge Internal USB-C PD PSU for Atari ST/STE/Mega ST` |
| ACSI2STM | `ACSI2STM Hard Disk for ST/MegaST/STE/MegaSTE` | `ACSI2STM Compact` |
| ST2VGA | `ST2VGA family (Rev.3 & Enhanced)` | `ST2VGA family (Adapter & Enhanced Adapter)` |

Card descriptions, alt text, and machine lists were tightened too. URLs untouched.

### PSU page (`sidecartridge-psu/index.md`)

Frontmatter title, H1 hero, image alt and prose rewritten to use `SidecarTridge Mean Well PSU Kit` consistently. Slug `/sidecartridge-psu/` preserved.

### ST2VGA family page (`st2vga-family/index.md`)

Frontmatter title and H1 aligned to `ST2VGA family (Adapter & Enhanced Adapter)`. Hardware revision history section left untouched on purpose, since it describes board revisions of the Adapter rather than the product name.

### Croissant docs (`sidecartridge-keyboard/*.md`)

`STe` -> `STE` casing fix across body prose in 7 files (`before-buy.md`, `croissant-open-hardware.md`, `faq.md`, `hardware-installation.md`, `index.md`, `introduction.md`, `usb-on-croissant.md`), matching the same cleanup applied on the web in PR sidecartridge.github.io#89. Image paths, asset filenames and URLs untouched.

## What was deliberately left out

- ACSI2STM section internals (`acsi2stm-atari-st/*.md`): the docs there cover ACSI2STM as a hardware family and the `parent:` frontmatter / breadcrumbs tie back to the existing landing title. Leaving that pass for a separate PR to avoid breadcrumb churn.
- ST2VGA hardware revision history (`Revision 3`, etc.): those are board revision numbers, not product names.
- USB-C PD PSU bare-board doc (`sidecartridge-usb-c-pd-psu/index.md`): it documents the multi-rail converter board itself, which keeps its technical name. The home page card now points users at the canonical product name.